### PR TITLE
feat: 주행 진행도 API 구현

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/global/common/ApiResponse.java
+++ b/src/main/java/com/smooth/driving_analysis_service/global/common/ApiResponse.java
@@ -1,0 +1,74 @@
+package com.smooth.driving_analysis_service.global.common;
+
+import com.smooth.driving_analysis_service.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// ApiResponse.java
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApiResponse<T> {
+    private boolean success;
+    private int code;
+    private String message;
+    private T data;
+
+    // 성공 응답 생성
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(200) // 성공 코드는 200으로 통일
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 간단한 성공 응답 생성 (데이터 없음)
+    public static ApiResponse<Void> success(String message) {
+        return success(message, null);
+    }
+
+    // 예외 코드만 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .data(null)
+                .build();
+    }
+
+    // 예외 코드와 데이터를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    // 예외 코드와 사용자 정의 메시지를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(message != null ? message : errorCode.getMessage())
+                .data(null)
+                .build();
+    }
+
+    // 예외 코드, 사용자 정의 메시지, 데이터를 사용한 실패 응답 생성
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(message != null ? message : errorCode.getMessage())
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/global/exception/ErrorCode.java
+++ b/src/main/java/com/smooth/driving_analysis_service/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.smooth.driving_analysis_service.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    Integer getCode();
+    String getMessage();
+    HttpStatus getHttpStatus();
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/controller/ReportProgressController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/controller/ReportProgressController.java
@@ -1,0 +1,46 @@
+package com.smooth.driving_analysis_service.progress.controller;
+
+import com.smooth.driving_analysis_service.global.common.ApiResponse;
+import com.smooth.driving_analysis_service.progress.dto.ReportProgressDto;
+import com.smooth.driving_analysis_service.progress.service.ReportProgressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/report")
+@RequiredArgsConstructor
+public class ReportProgressController {
+
+    private final ReportProgressService reportProgressService;
+
+    @GetMapping("/progress")
+    public ApiResponse<ReportProgressDto> getProgress(@RequestParam("userId") String userIdParam) {
+        // 1) userId 정규화: "9" -> "user9", " user9 " -> "user9", "USER9" -> "user9"
+        String userId = normalizeUserId(userIdParam);
+
+        ReportProgressDto dto = reportProgressService.getProgress(userId);
+
+        String message = (dto.getTotalTrips() == 0)
+                ? "아직 주행 기록이 없습니다. 15회 달성 시 리포트가 생성됩니다."
+                : "진행도 조회가 완료되었습니다.";
+
+        return ApiResponse.success(message, dto);
+    }
+
+    /** 숫자만 들어오면 "user{n}"로, 이미 user-prefix면 소문자 user로 통일 */
+    private String normalizeUserId(String raw) {
+        if (raw == null) return null;
+        String v = raw.trim();
+
+        // 숫자만 들어온 경우:  "9" -> "user9"
+        if (v.matches("\\d+")) return "user" + v;
+
+        // 이미 user 접두어면 접두어만 소문자로 통일: "USER9" / "User9" -> "user9"
+        if (v.toLowerCase().startsWith("user")) {
+            return "user" + v.substring(4); // "user" 이후 그대로 유지
+        }
+
+        // 그 외는 원본 유지
+        return v;
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/domain/DrivingRecordDomain.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/domain/DrivingRecordDomain.java
@@ -1,0 +1,42 @@
+// src/main/java/com/smooth/driving_analysis_service/progress/domain/TripSummary.java
+package com.smooth.driving_analysis_service.progress.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trip_summary", indexes = {
+        @Index(name = "idx_trip_user", columnList = "user_id")
+})
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class DrivingRecordDomain {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long key;   // AUTO_INCREMENT PK
+
+    @Column(name = "trip_id", nullable = false)
+    private String tripId;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;   // ← VARCHAR이니까 String
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "avg_speed")
+    private Float avgSpeed;
+
+    @Column(name = "cruise_ratio")
+    private Float cruiseRatio;
+
+    @Column(name = "lane_change_count")
+    private Integer laneChangeCount;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/dto/ReportProgressDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/dto/ReportProgressDto.java
@@ -1,0 +1,11 @@
+package com.smooth.driving_analysis_service.progress.dto;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ReportProgressDto {
+    private long totalTrips;          // 누적 trip 수
+    private int threshold;            // 다음 스냅샷 임계치 (15)
+    private long remainingToThreshold;// 임계치까지 남은 개수 (0 미만 방지)
+    private double progressRate;      // 임계치 대비 진행률 (0.0 ~ 1.0)
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/exception/ProgressErrorCode.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/exception/ProgressErrorCode.java
@@ -1,0 +1,18 @@
+package com.smooth.driving_analysis_service.progress.exception;
+
+import com.smooth.driving_analysis_service.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProgressErrorCode implements ErrorCode {
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "리포트를 찾을 수 없습니다."),
+    INSUFFICIENT_TRIPS(HttpStatus.BAD_REQUEST, 2002, "리포트 생성 조건(15회 주행)을 만족하지 못했습니다."),
+    REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, 2003, "리포트가 이미 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/repository/DrivingRecordRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/repository/DrivingRecordRepository.java
@@ -1,0 +1,8 @@
+package com.smooth.driving_analysis_service.progress.repository;
+
+import com.smooth.driving_analysis_service.progress.domain.DrivingRecordDomain;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrivingRecordRepository extends JpaRepository<DrivingRecordDomain, Long> {
+    long countByUserId(String userId);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/service/ReportProgressService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/service/ReportProgressService.java
@@ -1,0 +1,31 @@
+package com.smooth.driving_analysis_service.progress.service;
+
+import com.smooth.driving_analysis_service.progress.domain.DrivingRecordDomain;
+import com.smooth.driving_analysis_service.progress.dto.ReportProgressDto;
+import com.smooth.driving_analysis_service.progress.repository.DrivingRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportProgressService {
+
+    private static final int SNAPSHOT_THRESHOLD = 15;
+
+    private final DrivingRecordRepository drivingTripRepository;
+
+    @Transactional(readOnly = true)
+    public ReportProgressDto getProgress(String userId) {
+        long total = drivingTripRepository.countByUserId(userId);
+        long remaining = Math.max(0, SNAPSHOT_THRESHOLD - total);
+        double progress = Math.min(1.0d, (double) total / SNAPSHOT_THRESHOLD);
+
+        return ReportProgressDto.builder()
+                .totalTrips(total)
+                .threshold(SNAPSHOT_THRESHOLD)
+                .remainingToThreshold(remaining)
+                .progressRate(progress)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 개요

- GET /report/progress API 구현
- 사용자별 누적 trip 수 조회 및 리포트 생성 조건 계산

## ✅주요 변경 사항

- ReportProgressController, ReportProgressService 추가
- COUNT(*) 기반 주행 기록 카운트 로직 구현
- 15회 달성까지 남은 개수 계산 및 응답 DTO 구성

## 🔍 테스트/검증 사항

- 로컬 MySQL 환경에서 API 호출 (curl, Postman) 정상 동작 확인
- userId에 따른 trip 카운트 정상 반영

## 📌 관련 US
- #2  
