### PR TITLE
feat: 달성여부 API 구현

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/progress/controller/ReportProgressController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/controller/ReportProgressController.java
@@ -1,6 +1,7 @@
 package com.smooth.driving_analysis_service.progress.controller;
 
 import com.smooth.driving_analysis_service.global.common.ApiResponse;
+import com.smooth.driving_analysis_service.progress.dto.ReportEligibilityDto;
 import com.smooth.driving_analysis_service.progress.dto.ReportProgressDto;
 import com.smooth.driving_analysis_service.progress.service.ReportProgressService;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,10 @@ public class ReportProgressController {
 
     private final ReportProgressService reportProgressService;
 
+    /** 진행도 파악 */
     @GetMapping("/progress")
-    public ApiResponse<ReportProgressDto> getProgress(@RequestParam("userId") String userIdParam) {
-        // 1) userId 정규화: "9" -> "user9", " user9 " -> "user9", "USER9" -> "user9"
-        String userId = normalizeUserId(userIdParam);
+    public ApiResponse<ReportProgressDto> getProgress(@RequestParam("userId") String userId) {
+        // 1) userId 정규화: "9" -> "user9", " user9 " -> "user9", "USER9" -> "user9
 
         ReportProgressDto dto = reportProgressService.getProgress(userId);
 
@@ -27,20 +28,14 @@ public class ReportProgressController {
         return ApiResponse.success(message, dto);
     }
 
-    /** 숫자만 들어오면 "user{n}"로, 이미 user-prefix면 소문자 user로 통일 */
-    private String normalizeUserId(String raw) {
-        if (raw == null) return null;
-        String v = raw.trim();
-
-        // 숫자만 들어온 경우:  "9" -> "user9"
-        if (v.matches("\\d+")) return "user" + v;
-
-        // 이미 user 접두어면 접두어만 소문자로 통일: "USER9" / "User9" -> "user9"
-        if (v.toLowerCase().startsWith("user")) {
-            return "user" + v.substring(4); // "user" 이후 그대로 유지
-        }
-
-        // 그 외는 원본 유지
-        return v;
+    /** (신규) 달성 여부 */
+    @GetMapping("/eligibility")
+    public ApiResponse<ReportEligibilityDto> getEligibility(@RequestParam("userId") String userId) {
+        ReportEligibilityDto dto = reportProgressService.getEligibility(userId);
+        String message = dto.isEligible()
+                ? "리포트 생성 조건(15회)을 달성했습니다."
+                : "리포트 생성까지 " + dto.getRemainingTrips() + "회 남았습니다.";
+        return ApiResponse.success(message, dto);
     }
+
 }

--- a/src/main/java/com/smooth/driving_analysis_service/progress/dto/ReportEligibilityDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/dto/ReportEligibilityDto.java
@@ -1,0 +1,15 @@
+package com.smooth.driving_analysis_service.progress.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportEligibilityDto {
+    private long totalTrips;     // 누적 주행 수
+    private int threshold;       // 기준(15)
+    private boolean isEligible;  // 15회 달성 여부
+    private long remainingTrips; // 부족한 개수(0 미만 방지)
+}

--- a/src/main/java/com/smooth/driving_analysis_service/progress/service/ReportProgressService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/progress/service/ReportProgressService.java
@@ -1,6 +1,6 @@
 package com.smooth.driving_analysis_service.progress.service;
 
-import com.smooth.driving_analysis_service.progress.domain.DrivingRecordDomain;
+import com.smooth.driving_analysis_service.progress.dto.ReportEligibilityDto;
 import com.smooth.driving_analysis_service.progress.dto.ReportProgressDto;
 import com.smooth.driving_analysis_service.progress.repository.DrivingRecordRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,21 +11,52 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReportProgressService {
 
-    private static final int SNAPSHOT_THRESHOLD = 15;
+    private static final int THRESHOLD = 15;
 
-    private final DrivingRecordRepository drivingTripRepository;
+    // ✅ 의미에 맞게 필드명 정리 + final 로 주입
+    private final DrivingRecordRepository drivingRecordRepository;
 
     @Transactional(readOnly = true)
-    public ReportProgressDto getProgress(String userId) {
-        long total = drivingTripRepository.countByUserId(userId);
-        long remaining = Math.max(0, SNAPSHOT_THRESHOLD - total);
-        double progress = Math.min(1.0d, (double) total / SNAPSHOT_THRESHOLD);
+    public ReportProgressDto getProgress(String rawUserId) {
+        // ✅ 숫자 "9"도 지원하려면 정규화 유지 (불필요하면 바로 rawUserId 사용)
+        String userId = normalizeUserId(rawUserId);
+
+        long total = drivingRecordRepository.countByUserId(userId);
+        long remaining = Math.max(0, THRESHOLD - total);
+        double progress = Math.min(1.0d, (double) total / THRESHOLD);
 
         return ReportProgressDto.builder()
                 .totalTrips(total)
-                .threshold(SNAPSHOT_THRESHOLD)
+                .threshold(THRESHOLD)
                 .remainingToThreshold(remaining)
                 .progressRate(progress)
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public ReportEligibilityDto getEligibility(String rawUserId) {
+        // ✅ 동일 로직 일관화
+        String userId = normalizeUserId(rawUserId);
+
+        long total = drivingRecordRepository.countByUserId(userId);
+        boolean eligible = total >= THRESHOLD;
+        long remaining = Math.max(0, THRESHOLD - total);
+
+        return ReportEligibilityDto.builder()
+                .totalTrips(total)
+                .threshold(THRESHOLD)
+                .isEligible(eligible)
+                .remainingTrips(remaining)
+                .build();
+    }
+
+    /** 숫자 "9" -> "user9", " USER9 " -> "user9" (숫자도 허용하려면 유지, 아니면 메서드 제거) */
+    private String normalizeUserId(String raw) {
+        if (raw == null) return null;
+        String s = raw.trim().toLowerCase();
+        if (s.matches("^\\d+$")) {
+            return "user" + s;
+        }
+        return s;
     }
 }


### PR DESCRIPTION
## 📝 개요
- GET /report/eligibility API 구현
- 사용자별 15회 달성 여부와 부족 개수 계산 로직 제공

## ✅ 주요 변경 사항

- ReportProgressService에 getEligibility 메서드 추가
  - 사용자별 총 주행 횟수 조회
  - 15회 달성 여부(isEligible) 및 부족 개수(remainingTrips) 계산
- ReportEligibilityDto 생성 및 반환 구조 확립
- Controller 단에서 GET /report/eligibility 엔드포인트 연결

## 📌 관련 US
- #2 