### PR TITLE
PR: T7.3.1 - 15회 도달 판정 read-model 및 스키마 추가 → US7.3 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/snapshot/dto/SnapshotThresholdViewDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/snapshot/dto/SnapshotThresholdViewDto.java
@@ -1,0 +1,17 @@
+package com.smooth.driving_analysis_service.snapshot.dto;
+
+public record SnapshotThresholdViewDto(
+        int threshold,              // 15
+        int currentCycleCount,      // 0..15
+        int missingTrips,           // max(15 - current, 0)
+        boolean willReachAfterNext, // current == 14
+        boolean eligibleNow,        // current >= 15 (보통 즉시 발행되어 0으로 리셋됨)
+        int cycleIndex              // 현재 사이클 번호
+) {
+    public static SnapshotThresholdViewDto of(int threshold, int current, int cycleIndex) {
+        int missing = Math.max(threshold - current, 0);
+        boolean willNext = (current == threshold - 1);
+        boolean eligible = (current >= threshold);
+        return new SnapshotThresholdViewDto(threshold, current, missing, willNext, eligible, cycleIndex);
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/snapshot/entity/CycleAccumulatorEntity.java
+++ b/src/main/java/com/smooth/driving_analysis_service/snapshot/entity/CycleAccumulatorEntity.java
@@ -1,0 +1,57 @@
+package com.smooth.driving_analysis_service.snapshot.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "cycle_accumulator")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CycleAccumulatorEntity {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "cycle_index", nullable = false)
+    private int cycleIndex; // 기본 1
+
+    @Column(name = "trip_count", nullable = false)
+    private int tripCount;  // 0..15
+
+    @Column(name = "first_trip_id")
+    private String firstTripId;
+
+    @Column(name = "last_trip_id")
+    private String lastTripId;
+
+    @Column(name = "rapid_sum", nullable = false)
+    private int rapidSum;
+
+    @Column(name = "hard_sum", nullable = false)
+    private int hardSum;
+
+    @Column(name = "lane_sum", nullable = false)
+    private int laneSum;
+
+    @Column(name = "turn_sum", nullable = false)
+    private int turnSum;
+
+    @Column(name = "distance_m", nullable = false)
+    private long distanceM;
+
+    @Column(name = "duration_s", nullable = false)
+    private long durationS;
+
+    public static CycleAccumulatorEntity newEmpty(Long userId) {
+        return CycleAccumulatorEntity.builder()
+                .userId(userId)
+                .cycleIndex(1)
+                .tripCount(0)
+                .rapidSum(0).hardSum(0).laneSum(0).turnSum(0)
+                .distanceM(0L).durationS(0L)
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/snapshot/repository/CycleAccumulatorRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/snapshot/repository/CycleAccumulatorRepository.java
@@ -1,0 +1,18 @@
+package com.smooth.driving_analysis_service.snapshot.repository;
+
+import com.smooth.driving_analysis_service.snapshot.entity.CycleAccumulatorEntity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CycleAccumulatorRepository extends JpaRepository<CycleAccumulatorEntity, Long> {
+
+    Optional<CycleAccumulatorEntity> findByUserId(Long userId);
+
+    /** T7.3.2에서 증가/리셋 시 동시성 제어용 */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from CycleAccumulatorEntity a where a.userId = :userId")
+    Optional<CycleAccumulatorEntity> findByUserIdForUpdate(@Param("userId") Long userId);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/snapshot/service/SnapshotThresholdService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/snapshot/service/SnapshotThresholdService.java
@@ -1,0 +1,37 @@
+package com.smooth.driving_analysis_service.snapshot.service;
+
+import com.smooth.driving_analysis_service.snapshot.dto.SnapshotThresholdViewDto;
+import com.smooth.driving_analysis_service.snapshot.entity.CycleAccumulatorEntity;
+import com.smooth.driving_analysis_service.snapshot.repository.CycleAccumulatorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SnapshotThresholdService {
+
+    public static final int THRESHOLD = 15;
+
+    private final CycleAccumulatorRepository accumulatorRepository;
+
+    /** 읽기 전용: 현재 사이클 진행도를 기반으로 15회 도달/임박 여부 판정 */
+    @Transactional(readOnly = true)
+    public SnapshotThresholdViewDto view(Long userId) {
+        CycleAccumulatorEntity acc = accumulatorRepository.findByUserId(userId)
+                .orElse(CycleAccumulatorEntity.newEmpty(userId));
+        return SnapshotThresholdViewDto.of(THRESHOLD, acc.getTripCount(), acc.getCycleIndex());
+    }
+
+    /** 다음 트립 저장 시 15회 도달 여부 */
+    @Transactional(readOnly = true)
+    public boolean willReachAfterNext(Long userId) {
+        return view(userId).willReachAfterNext();
+    }
+
+    /** 지금 당장 15회 이상인지(실무상 바로 발행되므로 true일 시간창은 짧음) */
+    @Transactional(readOnly = true)
+    public boolean eligibleNow(Long userId) {
+        return view(userId).eligibleNow();
+    }
+}

--- a/src/main/resources/db/migration/V7_3_1__create_cycle_accumulator.sql
+++ b/src/main/resources/db/migration/V7_3_1__create_cycle_accumulator.sql
@@ -1,0 +1,23 @@
+-- V7_3_1__create_user_cycle_accumulator.sql
+-- 목적: US7.3 T7.3.1 진행도/도달 판정용 누적 테이블 생성
+
+CREATE TABLE IF NOT EXISTS cycle_accumulator (
+                                                      user_id         BIGINT       NOT NULL PRIMARY KEY,      -- 유저별 1행
+                                                      cycle_index     INT          NOT NULL DEFAULT 1,        -- 현재 사이클 번호(1부터)
+                                                      trip_count      TINYINT UNSIGNED NOT NULL DEFAULT 0,    -- 0..15
+                                                      first_trip_id   VARCHAR(64)      NULL,                  -- 해당 사이클 첫 트립
+    last_trip_id    VARCHAR(64)      NULL,                  -- 해당 사이클 마지막 트립
+    rapid_sum       INT          NOT NULL DEFAULT 0,        -- 누적 급가속
+    hard_sum        INT          NOT NULL DEFAULT 0,        -- 누적 급제동
+    lane_sum        INT          NOT NULL DEFAULT 0,        -- 누적 차선변경
+    turn_sum        INT          NOT NULL DEFAULT 0,        -- 누적 급회전
+    distance_m      BIGINT       NOT NULL DEFAULT 0,        -- 누적 이동거리(m)
+    duration_s      BIGINT       NOT NULL DEFAULT 0,        -- 누적 주행시간(s)
+    updated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT chk_trip_count CHECK (trip_count BETWEEN 0 AND 15)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 조회/정렬 최적화(선택)
+CREATE INDEX IF NOT EXISTS idx_cycle_accu_updated_at
+    ON cycle_accumulator (updated_at);


### PR DESCRIPTION
# PR: feat(snapshot): US7.3 T7.3.1 – 15회 도달 판정 read-model 및 스키마 추가

## 목적
- US7.3의 **15회 도달 여부 판정**을 위해 누적 진행도 **읽기 모델(read-model)**과 **DB 스키마**를 선반영합니다.
- 다음 태스크(T7.3.2)에서 **after-commit 비동기 트리거**로 누적(+1) 및 스냅샷 확정/리셋을 연결하기 위한 **기반 작업**입니다.

---

## 구현/변경 사항
- Flyway 마이그레이션 추가: `V7_3_1__create_user_cycle_accumulator.sql`
  - 테이블 `user_cycle_accumulator` 생성 (`user_id` PK, `cycle_index`, `trip_count`, `first_trip_id`, `last_trip_id`,
    `rapid_sum`, `hard_sum`, `lane_sum`, `turn_sum`, `distance_m`, `duration_s`, `updated_at`)
- 엔티티: `snapshot.entity.CycleAccumulatorEntity`
- 리포지토리: `snapshot.repository.CycleAccumulatorRepository` (동시성 대비 `findByUserIdForUpdate` 준비)
- DTO: `snapshot.dto.SnapshotThresholdViewDto`
- 서비스: `snapshot.service.SnapshotThresholdService` (threshold=15 기준 **도달/임박 판정** 제공)
- (Task → US 머지) **T7.3.1 → US7.3**: 15회 도달 판정 read-model 및 스키마 추가

---

## 참고
- 관련 이슈/유저 스토리: Refs: **US7.3 / T7.3.1**
- 후속 작업: **T7.3.2** (after-commit 트리거 연동, 누적 +1, 15회 시 스냅샷 확정 & 리셋)
