### PR TITLE
PR: T7.2.1 - 마일스톤 도달 여부 확인 및 이벤트 발행 디버그 API 추가 → US7.2 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
@@ -4,8 +4,9 @@ import com.smooth.driving_analysis_service.global.common.ApiResponse;
 import com.smooth.driving_analysis_service.driving.repository.DrivingRecordRepository;
 import com.smooth.driving_analysis_service.reports.milestone.service.MilestoneTriggerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
-
+@Profile("dev")
 @RestController
 @RequiredArgsConstructor
 public class MilestoneDebugController {

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
@@ -1,0 +1,39 @@
+package com.smooth.driving_analysis_service.reports.milestone.controller;
+
+import com.smooth.driving_analysis_service.global.common.ApiResponse;
+import com.smooth.driving_analysis_service.driving.repository.DrivingRecordRepository;
+import com.smooth.driving_analysis_service.reports.milestone.service.MilestoneTriggerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class MilestoneDebugController {
+
+    private final MilestoneTriggerService milestoneTriggerService;
+    private final DrivingRecordRepository drivingRecordRepository;
+
+    // ✅ 이벤트 발행까지 포함 (T7.2.1 실제 동작 검증용)
+    @PostMapping("/_debug/milestone/check")
+    public ApiResponse<CheckResult> checkAndPublish(@RequestBody CheckRequest req) {
+        long total = drivingRecordRepository.countByUserId(req.userId());
+        boolean isMultiple = (total > 0 && total % 15 == 0);
+        boolean reached = milestoneTriggerService.onTripCommitted(req.userId()); // 이벤트 발행
+        return ApiResponse.success("milestone check (publish) 완료",
+                new CheckResult(req.userId(), total, isMultiple, reached));
+    }
+
+    // 👀 이벤트 발행 없이 상태만 미리보기
+    @GetMapping("/_debug/milestone/peek")
+    public ApiResponse<PeekResult> peek(@RequestParam Long userId) {
+        long total = drivingRecordRepository.countByUserId(userId);
+        boolean isMultiple = (total > 0 && total % 15 == 0);
+        return ApiResponse.success("milestone peek 완료",
+                new PeekResult(userId, total, isMultiple));
+    }
+
+    // 요청/응답 DTO (record로 간단히)
+    public record CheckRequest(Long userId) {}
+    public record CheckResult(Long userId, long totalCount, boolean multipleOf15, boolean milestoneReached) {}
+    public record PeekResult(Long userId, long totalCount, boolean multipleOf15) {}
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/dto/MilestoneReachedEvent.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/dto/MilestoneReachedEvent.java
@@ -1,0 +1,7 @@
+package com.smooth.driving_analysis_service.reports.milestone.dto;
+
+/**
+ * T7.2.1: 15회 배수 도달 시 발행되는 도메인 이벤트
+ * - T7.2.2/7.2.3에서 이 이벤트를 구독하여 실제 생성/아이템 적재 수행
+ */
+public record MilestoneReachedEvent(Long userId, int milestone) {}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneTriggerService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneTriggerService.java
@@ -1,0 +1,41 @@
+package com.smooth.driving_analysis_service.reports.milestone.service;
+
+import com.smooth.driving_analysis_service.driving.repository.DrivingRecordRepository;
+import com.smooth.driving_analysis_service.reports.milestone.dto.MilestoneReachedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * T7.2.1: 15의 배수 도달 판단 로직 + 커밋 트리거 연동
+ *  - 주행 커밋 시 호출
+ *  - READY 주행 누적이 15의 배수면 MilestoneReachedEvent 발행
+ *  - 실제 리포트 생성/아이템 적재는 T7.2.2 / T7.2.3에서 이 이벤트를 구독하여 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MilestoneTriggerService {
+
+    private static final int THRESHOLD = 15;
+
+    private final DrivingRecordRepository drivingRecordRepository;
+    private final ApplicationEventPublisher publisher;
+
+    @Transactional(readOnly = true)
+    public boolean onTripCommitted(Long userId) {
+        long totalReady = drivingRecordRepository.countByUserId(userId);
+        if (totalReady <= 0 || totalReady % THRESHOLD != 0) {
+            log.debug("[MilestoneTrigger] skip: userId={}, totalReady={}", userId, totalReady);
+            return false;
+        }
+        int milestone = Math.toIntExact(totalReady);
+        log.info("[MilestoneTrigger] reached: userId={}, milestone={}", userId, milestone);
+
+        // 👉 여기서 “이벤트만” 발행 (생성/적재는 다음 태스크에서)
+        publisher.publishEvent(new MilestoneReachedEvent(userId, milestone));
+        return true;
+    }
+}


### PR DESCRIPTION
## 목적
- 사용자 주행 수가 15회 단위에 도달했는지 확인하고, 해당 시점에 마일스톤 이벤트를 발행할 수 있도록 디버그 API를 추가했습니다.
- 실제 milestoneTriggerService를 호출해 이벤트 발행 여부까지 검증할 수 있습니다.

## 구현/변경 사항
- **MilestoneDebugController** 추가
  - `/_debug/milestone/peek` : 총 주행 수 조회 및 15회 배수 여부 확인 (이벤트 발행 없음)
  - `/_debug/milestone/check` : 주행 수 조회 + milestoneTriggerService 호출을 통한 이벤트 발행
- DrivingRecordRepository 연동 → `countByUserId()` 사용
- record DTO(`CheckRequest`, `CheckResult`, `PeekResult`) 정의로 요청/응답 구조 단순화

## 테스트
- 로컬 환경 검증
  - userId=3, totalCount=18 → multipleOf15=false → milestone 발행 불가 확인
  - userId=1, totalCount=15 → multipleOf15=true → milestoneReached=true 확인
- Postman / curl 호출 모두 정상 동작 확인

## 참고
- Refs: US7.2
- 추후 운영 반영 전 `@Profile("dev")` 적용 또는 삭제 필요
