### PR TITLE
PR: T7.2.2 - milestone_items 최근 15건 스냅샷 저장(멱등) 구현 → US7.2 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/driving/repository/DrivingRecordRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/repository/DrivingRecordRepository.java
@@ -1,10 +1,14 @@
 package com.smooth.driving_analysis_service.driving.repository;
 
 import com.smooth.driving_analysis_service.driving.entity.DrivingRecord;
+import com.smooth.driving_analysis_service.driving.entity.SummaryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface DrivingRecordRepository extends JpaRepository<DrivingRecord,Long> {
     long countByUserId(Long userId);
+    List<DrivingRecord> findTop15ByUserIdAndStatusOrderByEndTimeDesc(Long userId, SummaryStatus status);
 }

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneDebugController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 @Profile("dev")
+@RequestMapping("/api/driving-analysis/reports") // 네가 쓰고 있던 prefix 유지
 @RestController
 @RequiredArgsConstructor
 public class MilestoneDebugController {

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneMaterializeDebugController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneMaterializeDebugController.java
@@ -1,0 +1,24 @@
+package com.smooth.driving_analysis_service.reports.milestone.controller;
+
+import com.smooth.driving_analysis_service.global.common.ApiResponse;
+import com.smooth.driving_analysis_service.reports.milestone.service.MilestoneMaterializeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+@Profile("dev") // 운영 차단 권장
+@RestController
+@RequestMapping("/api/driving-analysis/reports") // ✅ prefix 유지
+@RequiredArgsConstructor
+public class MilestoneMaterializeDebugController {
+
+    private final MilestoneMaterializeService materializeService;
+
+    @PostMapping("/_debug/milestone/materialize")
+    public ApiResponse<MilestoneMaterializeService.MaterializeResult> materialize(@RequestBody Req req) {
+        var res = materializeService.materializeLatest15(req.userId());
+        return ApiResponse.success("materialize 완료", res);
+    }
+
+    public record Req(Long userId) {}
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneItem.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneItem.java
@@ -1,0 +1,27 @@
+package com.smooth.driving_analysis_service.reports.milestone.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+@Entity
+public class MilestoneItem {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long reportId;
+    private String drivingId;
+    private Integer orderNo;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneReport.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneReport.java
@@ -1,0 +1,30 @@
+package com.smooth.driving_analysis_service.reports.milestone.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+@Entity
+public class MilestoneReport {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Integer cycleNo;      // 15회 단위
+
+    private Integer totalTrips;   // 스냅샷 시점 누적
+    private Boolean isRead;
+
+    private LocalDateTime snapshotAt;
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (snapshotAt == null) snapshotAt = LocalDateTime.now();
+        if (isRead == null) isRead = false;
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneItemRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneItemRepository.java
@@ -1,0 +1,12 @@
+package com.smooth.driving_analysis_service.reports.milestone.repository;
+
+import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MilestoneItemRepository extends JpaRepository<MilestoneItem, Long> {
+    long countByReportId(Long reportId);
+    boolean existsByReportIdAndDrivingId(Long reportId, String drivingId);
+    List<MilestoneItem> findByReportIdOrderByOrderNoAsc(Long reportId);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneReportRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneReportRepository.java
@@ -1,0 +1,10 @@
+package com.smooth.driving_analysis_service.reports.milestone.repository;
+
+import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MilestoneReportRepository extends JpaRepository<MilestoneReport, Long> {
+    Optional<MilestoneReport> findByUserIdAndCycleNo(Long userId, Integer cycleNo);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneMaterializeService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneMaterializeService.java
@@ -1,0 +1,111 @@
+package com.smooth.driving_analysis_service.reports.milestone.service;
+
+import com.smooth.driving_analysis_service.driving.entity.DrivingRecord;
+import com.smooth.driving_analysis_service.driving.entity.SummaryStatus;
+import com.smooth.driving_analysis_service.driving.repository.DrivingRecordRepository;
+import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneItem;
+import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneReport;
+import com.smooth.driving_analysis_service.reports.milestone.repository.MilestoneItemRepository;
+import com.smooth.driving_analysis_service.reports.milestone.repository.MilestoneReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MilestoneMaterializeService {
+
+    private final DrivingRecordRepository drivingRecordRepository;
+    private final MilestoneReportRepository reportRepository;
+    private final MilestoneItemRepository itemRepository;
+
+    /**
+     * 15회 배수 도달 시점에 "최근 15건(완주)"을 스냅샷 테이블에 저장(멱등).
+     * - 엔티티 변경 없이, 레포 메서드(시그니처)에만 맞춰 구현
+     * - report(header) upsert + item(detail) UNIQUE(report_id, driving_id)로 중복 방지
+     */
+    @Transactional
+    public MaterializeResult materializeLatest15(Long userId) {
+        // 총합: 현재 레포 시그니처 기준 (COMPLETED만으로 카운트하려면 countByUserIdAndStatus 추가 후 교체 권장)
+        long total = drivingRecordRepository.countByUserId(userId);
+        if (total == 0 || total % 15 != 0) {
+            return MaterializeResult.notReady(userId, total);
+        }
+
+        int cycleNo = (int) (total / 15);
+
+        // report 헤더 upsert (userId+cycleNo 유니크 가정)
+        MilestoneReport report = reportRepository.findByUserIdAndCycleNo(userId, cycleNo)
+                .orElseGet(() -> reportRepository.save(
+                        MilestoneReport.builder()
+                                .userId(userId)
+                                .cycleNo(cycleNo)
+                                .totalTrips((int) total)
+                                .isRead(false)
+                                .build()
+                ));
+
+        // 최신 15건: "완주(COMPLETED)"만 대상
+        List<DrivingRecord> latest15 =
+                drivingRecordRepository.findTop15ByUserIdAndStatusOrderByEndTimeDesc(userId, SummaryStatus.COMPLETED);
+
+        int inserted = 0;
+        int skipped = 0;
+        int order = 1;
+
+        for (DrivingRecord dr : latest15) {
+            String drivingId = dr.getDrivingId();
+            if (drivingId == null) {
+                // driving_id가 비어있으면 스냅샷 품질을 위해 스킵
+                skipped++;
+                continue;
+            }
+
+            // 멱등: 이미 있으면 스킵
+            if (itemRepository.existsByReportIdAndDrivingId(report.getId(), drivingId)) {
+                skipped++;
+            } else {
+                try {
+                    itemRepository.save(
+                            MilestoneItem.builder()
+                                    .reportId(report.getId())
+                                    .drivingId(drivingId)
+                                    .orderNo(order)
+                                    .build()
+                    );
+                    inserted++;
+                } catch (DataIntegrityViolationException e) {
+                    // 동시성/중복 삽입 등 UNIQUE 제약 위반 시 안전 스킵
+                    skipped++;
+                }
+            }
+            order++;
+        }
+
+        int currentItems = (int) itemRepository.countByReportId(report.getId());
+        return MaterializeResult.ready(userId, report.getId(), (int) total, inserted, skipped, currentItems);
+    }
+
+    // 응답 DTO(디버그 컨트롤러와 연동)
+    public record MaterializeResult(
+            Long userId,
+            Long reportId,
+            int totalTrips,
+            boolean ready,
+            int inserted,
+            int skipped,
+            int currentItems
+    ) {
+        public static MaterializeResult notReady(Long userId, long totalTrips) {
+            return new MaterializeResult(userId, null, (int) totalTrips, false, 0, 0, 0);
+        }
+        public static MaterializeResult ready(
+                Long userId, Long reportId, int totalTrips, int inserted, int skipped, int currentItems
+        ) {
+            return new MaterializeResult(userId, reportId, totalTrips, true, inserted, skipped, currentItems);
+        }
+    }
+}


### PR DESCRIPTION
## 목적
- 15회 달성 시점의 최근 15건 주행을 리포트 상세(milestone_items)로 스냅샷하여 노출/분석의 일관성을 보장합니다.
- 동일 작업 재실행 시에도 중복 저장 없이 멱등하게 동작하도록 합니다.

## 구현/변경 사항
- MilestoneMaterializeService
  - `materializeLatest15(userId)` 구현
  - COMPLETED 기준 최신 15건 조회 후 item 저장(중복 체크)
- Debug 엔드포인트 (prefix 유지: `/api/driving-analysis/reports`)
  - `POST /_debug/milestone/materialize` : 스냅샷 실행
  - (참고) `GET /_debug/milestone/peek`, `POST /_debug/milestone/check` 연동 확인
- DrivingRecordRepository
  - `findTop15ByUserIdAndStatusOrderByEndTimeDesc(Long, SummaryStatus)` 추가
  - (기존 엔티티/테이블 변경 없음)

## 테스트
- userId=1 (완주 15회)  
  - `peek` → `multipleOf15=true`
  - `materialize` 최초: `inserted=15, currentItems=15`  
  - 동일 요청 재실행: `inserted=0, skipped=15, currentItems=15` (멱등 확인)
- userId=3 (18회)  
  - `materialize` → `ready=false` (15의 배수 아님)

## 확인 명령어
```powershell
curl "http://localhost:8080/api/driving-analysis/reports/_debug/milestone/peek?userId=1"

$body = @{ userId = 1 } | ConvertTo-Json
Invoke-RestMethod -Method Post "http://localhost:8080/api/driving-analysis/reports/_debug/milestone/materialize" `
  -ContentType "application/json" -Body $body
