### PR TITLE
PR: T7.2.3 - 리포트 읽음 토글/설정 API(PATCH /{id}/read) 구현 → US7.2 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneReadController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/controller/MilestoneReadController.java
@@ -1,0 +1,31 @@
+package com.smooth.driving_analysis_service.reports.milestone.controller;
+
+import com.smooth.driving_analysis_service.global.common.ApiResponse;
+import com.smooth.driving_analysis_service.reports.milestone.service.MilestoneReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/driving-analysis/reports") // ✅ prefix 유지
+public class MilestoneReadController {
+
+    private final MilestoneReadService service;
+
+    // 본문이 없거나 {"read": null} 이면 토글, {"read": true/false}면 설정
+    @PatchMapping("/{id}/read")
+    public ApiResponse<MilestoneReadService.ReadResult> patchRead(
+            @PathVariable Long id,
+            @RequestBody(required = false) ReadRequest req
+    ) {
+        if (req == null || req.read() == null) {
+            var res = service.toggle(id);
+            return ApiResponse.success("read toggled", res);
+        } else {
+            var res = service.set(id, req.read());
+            return ApiResponse.success("read set", res);
+        }
+    }
+
+    public record ReadRequest(Boolean read) {}
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneReport.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/entity/MilestoneReport.java
@@ -27,4 +27,8 @@ public class MilestoneReport {
         if (snapshotAt == null) snapshotAt = LocalDateTime.now();
         if (isRead == null) isRead = false;
     }
+
+    public void setRead(boolean read) {
+        this.isRead = read;
+    }
 }

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneReadService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/service/MilestoneReadService.java
@@ -1,0 +1,41 @@
+package com.smooth.driving_analysis_service.reports.milestone.service;
+
+import com.smooth.driving_analysis_service.global.exception.BusinessException;
+import com.smooth.driving_analysis_service.global.exception.CommonErrorCode;
+import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneReport;
+import com.smooth.driving_analysis_service.reports.milestone.repository.MilestoneReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class MilestoneReadService {
+
+    private final MilestoneReportRepository reportRepository;
+
+    @Transactional
+    public ReadResult toggle(Long reportId) {
+        MilestoneReport report = find(reportId);
+        boolean prev = Boolean.TRUE.equals(report.getIsRead());
+        report.setRead(!prev);
+        return new ReadResult(report.getId(), prev, report.getIsRead(), "toggle");
+    }
+
+    @Transactional
+    public ReadResult set(Long reportId, boolean read) {
+        MilestoneReport report = find(reportId);
+        boolean prev = Boolean.TRUE.equals(report.getIsRead());
+        report.setRead(read);
+        return new ReadResult(report.getId(), prev, report.getIsRead(), "set");
+    }
+
+    private MilestoneReport find(Long id) {
+        return reportRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "report not found: " + id));
+    }
+
+    public record ReadResult(Long reportId, boolean previous, boolean current, String mode) {}
+}


### PR DESCRIPTION
## 목적
- 운전자가 생성된 마일스톤 리포트의 읽음 상태를 토글/설정할 수 있도록 합니다.

## 구현/변경 사항
- MilestoneReadService
  - toggle(reportId), set(reportId, read) 구현
- MilestoneReadController
  - PATCH /api/driving-analysis/reports/{id}/read
  - Body 없으면 토글, {"read": true|false}면 설정
- MilestoneReport 엔티티에 도메인 메서드 setRead(boolean) 추가

## 테스트
- 토글: `{}` 본문으로 요청 → previous ↔ current 전환 확인
- 설정: `{"read": true/false}` → idempotent 동작 확인
- DB 확인: `SELECT id, is_read FROM milestone_report WHERE id=?`

- 읽음으로 설정 (true)
$body = @{ read = $true } | ConvertTo-Json
Invoke-RestMethod -Method Patch "http://localhost:8080/api/driving-analysis/reports/1/read" `
  -ContentType "application/json" `
  -Body $body

- 읽지 않음으로 설정 (false)
$body = @{ read = $false } | ConvertTo-Json
Invoke-RestMethod -Method Patch "http://localhost:8080/api/driving-analysis/reports/1/read" `
  -ContentType "application/json" `
  -Body $body

- 토글 (본문 비우지 말고 {} 권장)
Invoke-RestMethod -Method Patch "http://localhost:8080/api/driving-analysis/reports/1/read" `
  -ContentType "application/json" `
  -Body "{}"


## 영향 범위
- reports/milestone 하위만 변경, driving 패키지 무변경
