### PR TITLE
# PR: US7.6 사고 반응 분석 기능 구현 완료 → dev 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionController.java
@@ -1,0 +1,45 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.controller;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.request.AccidentReactionRequestDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.response.AccidentReactionResponseDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.result.AccidentReactionResultDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.service.AccidentReactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/driving-analysis/reports/accident-reaction")
+@RequiredArgsConstructor
+public class AccidentReactionController {
+
+    private final AccidentReactionService service;
+
+    @PostMapping("/alerts/{alertId}/rendered")
+    public ResponseEntity<?> rendered(
+            @PathVariable String alertId,
+            @RequestParam long userId,
+            @RequestBody AccidentReactionRequestDto req
+    ) {
+        AccidentReactionResponseDto data = service.recordRendered(alertId, userId, req);
+        return ResponseEntity.ok(Map.of(
+                "success", true, "code", 200, "message", "알림 렌더 수신", "data", data
+        ));
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<?> summary(
+            @RequestParam long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to
+    ) {
+        AccidentReactionResultDto data = service.summary(userId, from, to);
+        return ResponseEntity.ok(Map.of(
+                "success", true, "code", 200, "message", "사고 알림 반응 요약", "data", data
+        ));
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/request/AccidentReactionRequestDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/request/AccidentReactionRequestDto.java
@@ -1,0 +1,9 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.request;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AccidentReactionRequestDto {
+    private long renderedAtMs;          // 프론트 그대로
+    private String type;                // "accident-nearby" | "obstacle"
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/response/AccidentReactionResponseDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/response/AccidentReactionResponseDto.java
@@ -1,0 +1,12 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.response;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AccidentReactionResponseDto {
+    private String alertId;
+    private long userId;
+    private String drivingId;        // 서버에서 자동 추적된 값
+    private long serverReceivedAtMs;
+    private boolean analysisScheduled;
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/result/AccidentReactionResultDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/result/AccidentReactionResultDto.java
@@ -1,0 +1,11 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.result;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AccidentReactionResultDto {
+    private int alertsReceived;
+    private Long avgResponseMs;
+    private double brakeOrStopRatio;
+    private double evasiveRatio;
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3DrivingEventRecordDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3DrivingEventRecordDto.java
@@ -1,0 +1,4 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.s3;
+
+public class S3DrivingEventRecordDto {
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3PreEventSeriesDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3PreEventSeriesDto.java
@@ -1,0 +1,4 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.s3;
+
+public class S3PreEventSeriesDto {
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3TimeSeriesSampleDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/dto/s3/S3TimeSeriesSampleDto.java
@@ -1,0 +1,4 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.dto.s3;
+
+public class S3TimeSeriesSampleDto {
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/entity/AccidentReactionMetric.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/entity/AccidentReactionMetric.java
@@ -1,0 +1,43 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Table(name = "accident_reaction_metric",
+        uniqueConstraints = @UniqueConstraint(name="uk_metric_alert", columnNames = {"alert_id"}),
+        indexes = @Index(name="ix_metric_user", columnList="user_id"))
+public class AccidentReactionMetric {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="alert_id", nullable=false, length=64)
+    private String alertId;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    @Column(name="reaction_ms")
+    private Integer reactionMs;
+
+    @Column(name="responded", nullable=false)
+    private boolean responded;
+
+    @Column(name="decel_or_stop", nullable=false)
+    private boolean decelOrStop;
+
+    @Column(name="evasive_maneuver", nullable=false)
+    private boolean evasiveManeuver;
+
+    @Column(name="window_s", nullable=false)
+    private int windowSec;
+
+    @CreationTimestamp
+    @Column(name="created_at", nullable=false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/entity/AlertRenderEvent.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/entity/AlertRenderEvent.java
@@ -1,0 +1,40 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Table(name = "alert_render_event",
+        uniqueConstraints = @UniqueConstraint(name="uk_render_unique", columnNames = {"alert_id"}),
+        indexes = {
+                @Index(name="ix_render_user_time", columnList="user_id,rendered_at"),
+                @Index(name="ix_render_driving", columnList="driving_id")
+        })
+public class AlertRenderEvent {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="alert_id", nullable=false, length=64)
+    private String alertId;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    @Column(name="type", nullable=false, length=32)
+    private String type; // "accident-nearby" | "obstacle"
+
+    @Column(name="rendered_at", nullable=false)
+    private LocalDateTime renderedAt;
+
+    @CreationTimestamp
+    @Column(name="received_at", nullable=false)
+    private LocalDateTime receivedAt;
+
+    @Column(name="driving_id", length=64)
+    private String drivingId; // 서버에서 자동 추적
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/repository/AccidentReactionMetricRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/repository/AccidentReactionMetricRepository.java
@@ -1,0 +1,20 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.repository;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.entity.AccidentReactionMetric;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface AccidentReactionMetricRepository extends JpaRepository<AccidentReactionMetric, Long> {
+
+    @Query("""
+      select count(m), avg(m.reactionMs),
+             avg(case when m.decelOrStop=true then 1.0 else 0.0 end),
+             avg(case when m.evasiveManeuver=true then 1.0 else 0.0 end)
+        from AccidentReactionMetric m
+       where m.userId = :userId
+         and m.createdAt between :from and :to
+    """)
+    Object[] summary(long userId, LocalDateTime from, LocalDateTime to);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/repository/AlertRenderEventRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/repository/AlertRenderEventRepository.java
@@ -1,0 +1,10 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.repository;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.entity.AlertRenderEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AlertRenderEventRepository extends JpaRepository<AlertRenderEvent, Long> {
+    Optional<AlertRenderEvent> findByAlertId(String alertId);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/AccidentReactionService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/AccidentReactionService.java
@@ -1,0 +1,74 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.service;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.request.AccidentReactionRequestDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.response.AccidentReactionResponseDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.dto.result.AccidentReactionResultDto;
+import com.smooth.driving_analysis_service.reports.accident_reaction.entity.AlertRenderEvent;
+import com.smooth.driving_analysis_service.reports.accident_reaction.repository.AccidentReactionMetricRepository;
+import com.smooth.driving_analysis_service.reports.accident_reaction.repository.AlertRenderEventRepository;
+import com.smooth.driving_analysis_service.reports.accident_reaction.service.DrivingIdResolverService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccidentReactionService {
+
+    private final AlertRenderEventRepository renderRepo;
+    private final AccidentReactionMetricRepository metricRepo;
+    private final ReactionAnalysisService analysisService;
+    private final DrivingIdResolverService drivingIdResolver;
+
+    @Transactional
+    public AccidentReactionResponseDto recordRendered(String alertId, long userId, AccidentReactionRequestDto req) {
+        LocalDateTime renderedAt = Instant.ofEpochMilli(req.getRenderedAtMs())
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+        String drivingId = drivingIdResolver.resolve(userId, renderedAt);
+
+        log.info("[사고반응] 알림 수신: alertId={}, userId={}, type={}, renderedAt={}, drivingId={}",
+                alertId, userId, req.getType(), renderedAt, drivingId);
+
+        AlertRenderEvent saved = renderRepo.save(AlertRenderEvent.builder()
+                .alertId(alertId)
+                .userId(userId)
+                .type(req.getType())
+                .renderedAt(renderedAt)
+                .drivingId(drivingId)
+                .build());
+
+        analysisService.scheduleAnalysis(saved);
+        log.info("[사고반응] 분석 스케줄링 완료: alertId={}", alertId);
+
+        return AccidentReactionResponseDto.builder()
+                .alertId(alertId)
+                .userId(userId)
+                .drivingId(drivingId)
+                .serverReceivedAtMs(Instant.now().toEpochMilli())
+                .analysisScheduled(true)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AccidentReactionResultDto summary(long userId, LocalDateTime from, LocalDateTime to) {
+        Object[] row = metricRepo.summary(userId, from, to);
+        int alerts = row[0] == null ? 0 : ((Number)row[0]).intValue();
+        Long avgMs = row[1] == null ? null : ((Number)row[1]).longValue();
+        double brake = row[2] == null ? 0.0 : ((Number)row[2]).doubleValue();
+        double evasive = row[3] == null ? 0.0 : ((Number)row[3]).doubleValue();
+
+        return AccidentReactionResultDto.builder()
+                .alertsReceived(alerts)
+                .avgResponseMs(avgMs)
+                .brakeOrStopRatio(brake)
+                .evasiveRatio(evasive)
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/AthenaReactionAnalyzerService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/AthenaReactionAnalyzerService.java
@@ -1,0 +1,191 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.service;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.support.DrivingEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.*;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AthenaReactionAnalyzerService {
+
+    private final AthenaClient athenaClient;
+
+    @Value("${athena.database}")
+    private String database;
+
+    @Value("${athena.output-location}")
+    private String outputLocation;
+
+    // 있으면 사용, 없으면 기본 event_data
+    @Value("${accident.reaction.athena.table:event_data}")
+    private String table;
+
+    @Value("${athena.workgroup:primary}")
+    private String workgroup;
+
+    /**
+     * drivingId가 있는 '타이트' 조회: 주어진 윈도우에서 가장 이른 이벤트 1건
+     */
+    public Optional<FoundEvent> findEarliestEvent(long userId, String drivingId, Instant from, Instant to) {
+        String sql = """
+            SELECT
+                event_type,
+                driving_id,
+                from_iso8601_timestamp(event_ts) AS ts
+            FROM %s.%s
+            WHERE user_id = %d
+              AND driving_id = '%s'
+              AND from_iso8601_timestamp(event_ts)
+                  BETWEEN from_iso8601_timestamp('%s') AND from_iso8601_timestamp('%s')
+            ORDER BY ts ASC
+            LIMIT 1
+        """.formatted(database, table, userId, esc(drivingId),
+                DateTimeFormatter.ISO_INSTANT.format(from),
+                DateTimeFormatter.ISO_INSTANT.format(to));
+
+        return executeSingle(sql);
+    }
+
+    /**
+     * drivingId 없이 '루즈' 조회: 주어진 윈도우에서 가장 이른 이벤트 1건
+     */
+    public Optional<FoundEvent> findEarliestEventLoose(long userId, Instant from, Instant to) {
+        String sql = """
+            SELECT
+                event_type,
+                driving_id,
+                from_iso8601_timestamp(event_ts) AS ts
+            FROM %s.%s
+            WHERE user_id = %d
+              AND from_iso8601_timestamp(event_ts)
+                  BETWEEN from_iso8601_timestamp('%s') AND from_iso8601_timestamp('%s')
+            ORDER BY ts ASC
+            LIMIT 1
+        """.formatted(database, table, userId,
+                DateTimeFormatter.ISO_INSTANT.format(from),
+                DateTimeFormatter.ISO_INSTANT.format(to));
+
+        return executeSingle(sql);
+    }
+
+    /* ======================== 내부 공통 루틴 (네 Impl 스타일) ======================== */
+
+    private Optional<FoundEvent> executeSingle(String sql) {
+        try {
+            log.info("[사고반응][Athena] 쿼리 실행: workgroup={}, database={}, table={}", workgroup, database, table);
+            String executionId = startQuery(sql);
+
+            // 완료 대기
+            waitForQueryCompletion(executionId);
+
+            // 결과 조회
+            GetQueryResultsResponse res = athenaClient.getQueryResults(GetQueryResultsRequest.builder()
+                    .queryExecutionId(executionId)
+                    .build());
+
+            List<Row> rows = res.resultSet().rows();
+            if (rows == null || rows.size() <= 1) {
+                log.info("[사고반응][Athena] 결과 없음(헤더만 존재): executionId={}", executionId);
+                return Optional.empty();
+            }
+
+            // 헤더
+            List<String> headers = rows.get(0).data().stream().map(Datum::varCharValue).toList();
+
+            // 첫 번째 데이터 로우
+            Row r = rows.get(1);
+            Map<String, String> rowMap = new HashMap<>();
+            for (int i = 0; i < headers.size(); i++) {
+                rowMap.put(headers.get(i), r.data().get(i).varCharValue());
+            }
+
+            String eventTypeStr = rowMap.getOrDefault("event_type", null);
+            String drivingIdStr = rowMap.getOrDefault("driving_id", null);
+            String tsStr        = rowMap.getOrDefault("ts", null);
+
+            Instant ts = parseAthenaInstant(tsStr);
+
+            log.info("[사고반응][Athena] 쿼리 성공: executionId={}, eventType={}, drivingId={}, ts={}",
+                    executionId, eventTypeStr, drivingIdStr, ts);
+            return Optional.of(new FoundEvent(DrivingEventType.of(eventTypeStr), drivingIdStr, ts));
+
+        } catch (Exception e) {
+            log.error("[사고반응][Athena] 쿼리 실행 실패: {}", e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    private String startQuery(String query) {
+        ResultConfiguration resultConfiguration = ResultConfiguration.builder()
+                .outputLocation(outputLocation)
+                .build();
+
+        StartQueryExecutionRequest request = StartQueryExecutionRequest.builder()
+                .queryString(query)
+                .workGroup(workgroup)
+                .queryExecutionContext(QueryExecutionContext.builder().database(database).build())
+                .resultConfiguration(resultConfiguration)
+                .build();
+
+        StartQueryExecutionResponse response = athenaClient.startQueryExecution(request);
+        return response.queryExecutionId();
+    }
+
+    private void waitForQueryCompletion(String executionId) throws InterruptedException {
+        GetQueryExecutionRequest request = GetQueryExecutionRequest.builder()
+                .queryExecutionId(executionId)
+                .build();
+
+        QueryExecutionState state;
+        do {
+            Thread.sleep(800); // Athena 특성상 0.4s보단 약간 여유
+            GetQueryExecutionResponse response = athenaClient.getQueryExecution(request);
+            state = response.queryExecution().status().state();
+            log.debug("[사고반응][Athena] 실행 상태: executionId={}, state={}", executionId, state);
+
+            if (state == QueryExecutionState.FAILED || state == QueryExecutionState.CANCELLED) {
+                String reason = response.queryExecution().status().stateChangeReason();
+                throw new RuntimeException("Athena 쿼리 실패: " + reason);
+            }
+
+        } while (state == QueryExecutionState.RUNNING || state == QueryExecutionState.QUEUED);
+    }
+
+    private static String esc(String s) {
+        return s.replace("'", "''");
+    }
+
+    /**
+     * Athena가 반환하는 타임스탬프 문자열 안전 파싱
+     * - 예: "2025-08-20 05:10:22.000 UTC" → "2025-08-20T05:10:22.000Z"
+     * - ISO 인풋도 그대로 처리
+     */
+    private static Instant parseAthenaInstant(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            // ISO 형태면 바로
+            return Instant.parse(raw);
+        } catch (Exception ignore) {
+        }
+        try {
+            // "YYYY-MM-DD HH:MM:SS(.SSS) UTC" → ISO로 치환
+            String isoLike = raw.replace(' ', 'T').replace(" UTC", "Z");
+            return Instant.parse(isoLike);
+        } catch (Exception e) {
+            log.warn("[사고반응][Athena] 타임스탬프 파싱 실패: {}", raw, e);
+            return null;
+        }
+    }
+
+    /** 결과 모델 (그대로 유지) */
+    public record FoundEvent(DrivingEventType type, String drivingId, Instant eventInstant) {}
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/DrivingIdResolverImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/DrivingIdResolverImpl.java
@@ -1,0 +1,72 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.service;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.service.DrivingIdResolverService;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DrivingIdResolverImpl implements DrivingIdResolverService {
+
+    private final EntityManager em;
+
+    @Value("${accident.reaction.resolve.bufferSec:300}")
+    private int bufferSec;
+
+    @Override
+    @Transactional(readOnly = true)
+    public String resolve(long userId, LocalDateTime t) {
+        // 1) 포함 검색
+        List<String> exact = em.createQuery("""
+            select r.drivingId
+              from DrivingRecord r
+             where r.userId = :u
+               and r.startTime <= :t
+               and r.endTime   >= :t
+             order by (r.endTime - r.startTime) asc
+        """, String.class)
+                .setParameter("u", userId)
+                .setParameter("t", t)
+                .setMaxResults(1)
+                .getResultList();
+
+        if (!exact.isEmpty()) {
+            log.info("[사고반응] drivingId 확인(포함 일치): userId={}, renderedAt={}, drivingId={}", userId, t, exact.get(0));
+            return exact.get(0);
+        }
+
+        // 2) 근접 검색(옵션)
+        LocalDateTime from = t.minusSeconds(bufferSec);
+        LocalDateTime to   = t.plusSeconds(bufferSec);
+        List<String> near = em.createQuery("""
+            select r.drivingId
+              from DrivingRecord r
+             where r.userId = :u
+               and (r.startTime between :f and :to
+                 or r.endTime   between :f and :to)
+             order by abs(timestampdiff(second, r.startTime, :t)) asc
+        """, String.class)
+                .setParameter("u", userId)
+                .setParameter("f", from)
+                .setParameter("to", to)
+                .setParameter("t", t)
+                .setMaxResults(1)
+                .getResultList();
+
+        if (!near.isEmpty()) {
+            log.info("[사고반응] drivingId 확인(근접 일치): userId={}, renderedAt={}, drivingId={}", userId, t, near.get(0));
+            return near.get(0);
+        }
+
+        log.warn("[사고반응] drivingId 매칭 실패: userId={}, renderedAt={}", userId, t);
+        return null;
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/DrivingIdResolverService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/DrivingIdResolverService.java
@@ -1,0 +1,8 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.service;
+
+import java.time.LocalDateTime;
+
+public interface DrivingIdResolverService {
+    /** renderedAt을 포함(1순위) 또는 근접(옵션)하는 drivingId 반환. 없으면 null */
+    String resolve(long userId, LocalDateTime renderedAt);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/ReactionAnalysisService.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/service/ReactionAnalysisService.java
@@ -1,0 +1,91 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.service;
+
+import com.smooth.driving_analysis_service.reports.accident_reaction.entity.AccidentReactionMetric;
+import com.smooth.driving_analysis_service.reports.accident_reaction.entity.AlertRenderEvent;
+import com.smooth.driving_analysis_service.reports.accident_reaction.repository.AccidentReactionMetricRepository;
+import com.smooth.driving_analysis_service.reports.accident_reaction.service.AthenaReactionAnalyzerService;
+import com.smooth.driving_analysis_service.reports.accident_reaction.support.DrivingEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReactionAnalysisService {
+
+    private final AccidentReactionMetricRepository metricRepo;
+    private final AthenaReactionAnalyzerService athena;
+
+    @Value("${accident.reaction.analysis.windowSec:120}")
+    private int analysisWindowSec;
+
+    @Value("${accident.reaction.athena.enabled:true}")
+    private boolean athenaEnabled;
+
+    @Async
+    @Transactional
+    public void scheduleAnalysis(AlertRenderEvent render) {
+        try {
+            Instant from = render.getRenderedAt().atZone(ZoneId.systemDefault()).toInstant();
+            Instant to   = from.plusSeconds(analysisWindowSec);
+
+            log.info("[사고반응] 분석 시작: alertId={}, userId={}, drivingId={}, windowSec={}",
+                    render.getAlertId(), render.getUserId(), render.getDrivingId(), analysisWindowSec);
+
+            Optional<AthenaReactionAnalyzerService.FoundEvent> found =
+                    (render.getDrivingId() != null && !render.getDrivingId().isBlank())
+                            ? athena.findEarliestEvent(render.getUserId(), render.getDrivingId(), from, to)
+                            : athena.findEarliestEventLoose(render.getUserId(), from, to);
+
+            Integer reactionMs = null;
+            boolean responded = false;
+            boolean decelOrStop = false;
+            boolean evasive = false;
+
+            if (found.isPresent()) {
+                var ev = found.get();
+                responded  = true;
+                reactionMs = Math.toIntExact(ev.eventInstant().toEpochMilli() - from.toEpochMilli());
+
+                DrivingEventType t = ev.type();
+                if (t != null) {
+                    switch (t) {
+                        case HARD_BRAKE -> decelOrStop = true;
+                        case LANE_CHANGE, SHARP_TURN -> evasive = true;
+                        case RAPID_ACCEL -> { /* 정책상 플래그 미설정(필요시 변경) */ }
+                    }
+                }
+
+                log.info("[사고반응] 최초 이벤트 발견: alertId={}, eventType={}, eventDrivingId={}, reactionMs={}",
+                        render.getAlertId(), t, ev.drivingId(), reactionMs);
+            } else {
+                log.warn("[사고반응] 윈도우 내 이벤트 미발견: alertId={}, windowSec={}",
+                        render.getAlertId(), analysisWindowSec);
+            }
+
+            metricRepo.save(AccidentReactionMetric.builder()
+                    .alertId(render.getAlertId())
+                    .userId(render.getUserId())
+                    .reactionMs(reactionMs)
+                    .responded(responded)
+                    .decelOrStop(decelOrStop)
+                    .evasiveManeuver(evasive)
+                    .windowSec(analysisWindowSec)
+                    .build());
+
+            log.info("[사고반응] 메트릭 저장 완료: alertId={}, 반응여부={}, 반응시간(ms)={}",
+                    render.getAlertId(), responded, reactionMs);
+
+        } catch (Exception e) {
+            log.error("[사고반응] 분석 실패: alertId={}, 사유={}", render.getAlertId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/support/DrivingEventType.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/support/DrivingEventType.java
@@ -1,0 +1,17 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.support;
+
+public enum DrivingEventType {
+    RAPID_ACCEL("rapid_accel"),
+    HARD_BRAKE("hard_brake"),
+    LANE_CHANGE("lane_change"),
+    SHARP_TURN("sharp_turn");
+
+    private final String json;
+    DrivingEventType(String json) { this.json = json; }
+    public static DrivingEventType of(String s) {
+        if (s == null) return null;
+        String k = s.trim().toLowerCase();
+        for (var t : values()) if (t.json.equals(k)) return t;
+        return null;
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/support/ReactionType.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/support/ReactionType.java
@@ -1,0 +1,16 @@
+package com.smooth.driving_analysis_service.reports.accident_reaction.support;
+
+public enum ReactionType {
+    ACCIDENT_NEARBY("accident-nearby"),
+    OBSTACLE("obstacle");
+
+    private final String apiName;
+    ReactionType(String apiName) { this.apiName = apiName; }
+
+    public static ReactionType of(String raw) {
+        if (raw == null) return null;
+        String k = raw.trim().toLowerCase();
+        for (var t : values()) if (t.apiName.equals(k)) return t;
+        return null;
+    }
+}


### PR DESCRIPTION
## 목적
- Epic 7(리포트 분석) 중 User Story US7.6(사고 반응 분석) 완료
- 프론트에서 전달한 사고 알림 이후 사용자 반응을 RDS+Athena로 분석하는 기능 구현

---

## 구현/변경 사항
- T7.6.1: AccidentReactionController 추가 및 API 엔드포인트 구현
- T7.6.2: AlertRenderEvent/AccidentReactionMetric 엔티티 및 레포지토리 작성
- T7.6.3: AthenaReactionAnalyzerService 구현 (주행 로그 기반 반응 탐지)
- T7.6.4: DrivingId Resolver 전략 적용 및 ResponseDto 매핑
- T7.6.5: 로깅 및 예외 처리 개선 (한국어 메시지 적용)

---

## 테스트
- Docker 기반 로컬 환경에서 Redis/MySQL 기동 후 API 호출 검증
- `POST /api/driving-analysis/reports/accident-reaction/alerts/rendered` → RDS insert 확인
- `GET /api/driving-analysis/reports/accident-reaction/analysis?alertId=...` → Athena 연동 및 응답 확인

---

## 참고
- 관련 이슈: Refs: US7.6
