### PR TITLE
PR: refactor -  JWT에서 유저 ID를 파싱하는 인증 관련 유틸리티 추가 -> dev 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // ===== Database Drivers =====
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/smooth/driving_analysis_service/global/auth/AuthenticationUtils.java
+++ b/src/main/java/com/smooth/driving_analysis_service/global/auth/AuthenticationUtils.java
@@ -1,0 +1,151 @@
+package com.smooth.driving_analysis_service.global.auth;
+
+import com.smooth.driving_analysis_service.global.exception.BusinessException;
+import com.smooth.driving_analysis_service.global.exception.CommonErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+
+// 인증 관련 유틸리티 클래스
+// Gateway에서 전달된 사용자 정보를 쉽게 추출할 수 있도록 도와줌
+
+@Slf4j
+public class AuthenticationUtils {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_EMAIL_HEADER = "X-User-Email";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String AUTHENTICATED_HEADER = "X-Authenticated";
+
+
+//     현재 인증된 사용자의 ID를 반환
+//     @return 사용자 ID (없으면 null)
+    public static Long getCurrentUserId() {
+        // 1. SecurityContext에서 먼저 시도
+        Long userIdFromSecurity = getUserIdFromSecurityContext();
+        if (userIdFromSecurity != null) {
+            return userIdFromSecurity;
+        }
+        // 2. HTTP 헤더에서 시도 (Fallback)
+        return getUserIdFromHeader();
+    }
+
+//     현재 인증된 사용자의 ID를 반환 (없으면 예외 발생)
+    public static Long getCurrentUserIdOrThrow() {
+        Long userId = getCurrentUserId();
+        if (userId == null) {
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+        }
+        return userId;
+    }
+
+
+//     현재 인증된 사용자의 이메일을 반환
+    public static String getCurrentUserEmail() {
+        // SecurityContext 우선, 실패하면 헤더에서
+        String emailFromSecurity = getUserEmailFromSecurityContext();
+        if (StringUtils.hasText(emailFromSecurity)) {
+            return emailFromSecurity;
+        }
+        return getUserEmailFromHeader();
+    }
+
+
+//     현재 인증된 사용자의 역할을 반환
+    public static String getCurrentUserRole() {
+        // Gateway에서 헤더로 전달된 role 정보 사용
+        return getUserRoleFromHeader();
+    }
+
+//     현재 사용자가 관리자인지 확인
+    public static boolean isAdmin() {
+        String role = getCurrentUserRole();
+        return "ADMIN".equals(role);
+    }
+
+//     현재 요청이 인증된 요청인지 확인
+    public static boolean isAuthenticated() {
+        return getCurrentUserId() != null;
+    }
+
+    // Private Helper Methods
+    
+    private static Long getUserIdFromSecurityContext() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof GatewayUserDetails) {
+                GatewayUserDetails userDetails = (GatewayUserDetails) authentication.getPrincipal();
+                return userDetails.getUserId();
+            }
+        } catch (Exception e) {
+            log.debug("SecurityContext에서 사용자 ID 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static Long getUserIdFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String userIdHeader = request.getHeader(USER_ID_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            if (StringUtils.hasText(userIdHeader) && "true".equals(authenticatedHeader)) {
+                return Long.valueOf(userIdHeader);
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 ID 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String getUserEmailFromSecurityContext() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof GatewayUserDetails) {
+                GatewayUserDetails userDetails = (GatewayUserDetails) authentication.getPrincipal();
+                return userDetails.getEmail();
+            }
+        } catch (Exception e) {
+            log.debug("SecurityContext에서 사용자 이메일 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String getUserEmailFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String emailHeader = request.getHeader(USER_EMAIL_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            if (StringUtils.hasText(emailHeader) && "true".equals(authenticatedHeader)) {
+                return emailHeader;
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 이메일 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String getUserRoleFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String roleHeader = request.getHeader(USER_ROLE_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            if (StringUtils.hasText(roleHeader) && "true".equals(authenticatedHeader)) {
+                return roleHeader;
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 역할 추출 실패: {}", e.getMessage());
+        }
+        return "USER"; // 기본값
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/global/auth/GatewayUserDetails.java
+++ b/src/main/java/com/smooth/driving_analysis_service/global/auth/GatewayUserDetails.java
@@ -1,0 +1,52 @@
+package com.smooth.driving_analysis_service.global.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@RequiredArgsConstructor
+public class GatewayUserDetails implements UserDetails {
+    
+    private final Long userId;
+    private final String email;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // Gateway 인증에서는 비밀번호 불필요
+    }
+
+    @Override
+    public String getUsername() {
+        return userId.toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}


### PR DESCRIPTION
## 목적
- 이 PR이 필요한 이유 또는 배경을 간단히 작성합니다.
- (예: KST 시간 파싱 오류 수정, 실시간 알림 기능 구현, Redis 구조 리팩토링 등)


## 구현/변경 사항
- <주요 기능/코드 변경 1줄 요약>
- <주요 기능/코드 변경 1줄 요약>
- <주요 기능/코드 변경 1줄 요약>
- (Task → US 머지일 경우 하위 Task 번호와 설명을 목록화)


## 테스트 (있을 경우만 작성)
- <테스트 환경> (예: Docker 기반 로컬 환경, staging 서버 등)
- <테스트 방법> (예: REST API 호출, WebSocket 연결, 단위 테스트 실행 등)
- <검증 결과> (예: 메시지 수신 정상, 반경 필터링 성공, 예외 처리 통과 등)


## BREAKING CHANGE (있을 경우만 작성)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)


## 참고
- 관련 이슈/유저 스토리: Refs: US<번호> (또는 Task 번호)
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)