### PR TITLE
# PR: feat · US7.5 운전 행동 분석 API Task 2 구현 - drivingPattern

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/projection/EventPatternProjection.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/projection/EventPatternProjection.java
@@ -1,0 +1,12 @@
+package com.smooth.driving_analysis_service.reports.behavior.dto.projection;
+
+/**
+ * Athena 쿼리 결과를 매핑하기 위한 Projection 인터페이스
+ * S3 event_data에서 요일별, 시간대별, 행동별 집계 데이터
+ */
+public interface EventPatternProjection {
+    Integer getWeekday();        // 1=월요일, 2=화요일, ..., 7=일요일
+    String getTimeSlot();        // DAWN, COMMUTE_TO_WORK, DAYTIME, COMMUTE_FROM_WORK, EVENING
+    String getEventType();       // rapid_accel, hard_brake, lane_change
+    Integer getEventCount();     // 해당 조건의 이벤트 발생 횟수
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/response/BehaviorAnalysisResponseDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/response/BehaviorAnalysisResponseDto.java
@@ -8,8 +8,7 @@ public class BehaviorAnalysisResponseDto {
     
     private String reportId;
     private TotalCounts totalCounts;
-    // TODO: Task 2에서 구현
-    // private DrivingPattern drivingPattern;
+    private DrivingPattern drivingPattern;  // Task 2에서 구현
     // TODO: Task 3에서 구현  
     // private Compare compare;
     

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/response/DrivingPatternDto.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/dto/response/DrivingPatternDto.java
@@ -1,0 +1,47 @@
+package com.smooth.driving_analysis_service.reports.behavior.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrivingPatternDto {
+    private String weekday;       // 가장 위험행동이 많은 요일
+    private String timeslot;      // 가장 위험행동이 많은 시간대
+    private List<WeeklyChartDto> chart;  // 라인차트용
+    private String comment;       // 패턴 분석 코멘트
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WeeklyChartDto {
+        private String weekday;       // "월", "화", ...
+        private ActionsDto actions;   // 행동별 시간대 정보
+    }
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ActionsDto {
+        private ActionTimeSlotDto hardBrake;
+        private ActionTimeSlotDto rapidAccel;
+        private ActionTimeSlotDto laneChange;
+    }
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ActionTimeSlotDto {
+        private String timeSlot;  // "새벽", "출근", "낮", "퇴근", "저녁"
+        private Integer count;    // 해당 시간대 발생 횟수
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/repository/BehaviorPatternRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/repository/BehaviorPatternRepository.java
@@ -1,0 +1,21 @@
+package com.smooth.driving_analysis_service.reports.behavior.repository;
+
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * S3 event_data를 Athena로 쿼리하여 위험행동 패턴을 분석하는 Repository
+ */
+@Repository
+public interface BehaviorPatternRepository {
+    
+    /**
+     * 특정 리포트의 drivingId들에 대해 요일별, 시간대별, 행동별 이벤트 패턴을 조회
+     * 
+     * @param reportId 리포트 ID
+     * @return 요일별, 시간대별, 행동별 집계 데이터
+     */
+    List<EventPatternProjection> findEventPatternsByReportId(Long reportId);
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/repository/BehaviorPatternRepositoryImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/repository/BehaviorPatternRepositoryImpl.java
@@ -1,0 +1,142 @@
+package com.smooth.driving_analysis_service.reports.behavior.repository;
+
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
+import com.smooth.driving_analysis_service.reports.milestone.repository.MilestoneItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class BehaviorPatternRepositoryImpl implements BehaviorPatternRepository {
+
+    private final MilestoneItemRepository milestoneItemRepository;
+
+    @Override
+    public List<EventPatternProjection> findEventPatternsByReportId(Long reportId) {
+        try {
+            // 1. 해당 리포트의 drivingId 목록 조회
+            List<String> drivingIds = milestoneItemRepository.findDrivingIdsByReportId(reportId);
+            
+            if (drivingIds.isEmpty()) {
+                log.warn("리포트에 해당하는 drivingId가 없습니다. reportId: {}", reportId);
+                return new ArrayList<>();
+            }
+
+            // 2. TODO: 실제 Athena 쿼리 구현 예정 - 현재는 Mock 데이터 사용
+            log.info("Mock 데이터 사용 - reportId: {}, drivingIds: {}", reportId, drivingIds);
+            return generateMockEventPatterns(drivingIds);
+
+        } catch (Exception e) {
+            log.error("이벤트 패턴 조회 실패 - reportId: {}", reportId, e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * TODO: 실제 Athena 쿼리로 대체 예정
+     * 현재는 테스트를 위한 Mock 데이터 생성
+     */
+    private List<EventPatternProjection> generateMockEventPatterns(List<String> drivingIds) {
+        List<EventPatternProjection> mockPatterns = new ArrayList<>();
+        
+        // 금요일 저녁에 가장 많은 위험행동이 발생하는 패턴 생성
+        mockPatterns.add(createMockProjection(5, "EVENING", "hard_brake", 8));
+        mockPatterns.add(createMockProjection(5, "EVENING", "rapid_accel", 6));
+        mockPatterns.add(createMockProjection(5, "EVENING", "lane_change", 7));
+        
+        // 평일 퇴근시간 패턴
+        mockPatterns.add(createMockProjection(1, "COMMUTE_FROM_WORK", "hard_brake", 3));
+        mockPatterns.add(createMockProjection(2, "COMMUTE_FROM_WORK", "hard_brake", 4));
+        mockPatterns.add(createMockProjection(3, "COMMUTE_FROM_WORK", "hard_brake", 2));
+        mockPatterns.add(createMockProjection(4, "COMMUTE_FROM_WORK", "hard_brake", 5));
+        
+        // 출근시간 급가속 패턴
+        mockPatterns.add(createMockProjection(1, "COMMUTE_TO_WORK", "rapid_accel", 2));
+        mockPatterns.add(createMockProjection(2, "COMMUTE_TO_WORK", "rapid_accel", 3));
+        mockPatterns.add(createMockProjection(3, "COMMUTE_TO_WORK", "rapid_accel", 1));
+        mockPatterns.add(createMockProjection(4, "COMMUTE_TO_WORK", "rapid_accel", 4));
+        
+        // 낮시간 차선변경 패턴
+        mockPatterns.add(createMockProjection(1, "DAYTIME", "lane_change", 2));
+        mockPatterns.add(createMockProjection(2, "DAYTIME", "lane_change", 3));
+        mockPatterns.add(createMockProjection(3, "DAYTIME", "lane_change", 1));
+        mockPatterns.add(createMockProjection(4, "DAYTIME", "lane_change", 2));
+        mockPatterns.add(createMockProjection(5, "DAYTIME", "lane_change", 4));
+        
+        return mockPatterns;
+    }
+
+    private EventPatternProjection createMockProjection(int weekday, String timeSlot, String eventType, int count) {
+        return new EventPatternProjection() {
+            @Override
+            public Integer getWeekday() { return weekday; }
+            
+            @Override
+            public String getTimeSlot() { return timeSlot; }
+            
+            @Override
+            public String getEventType() { return eventType; }
+            
+            @Override
+            public Integer getEventCount() { return count; }
+        };
+    }
+
+    // TODO: 실제 Athena 쿼리 구현시 사용할 메서드들
+    /*
+    private String buildEventPatternQuery(List<String> drivingIds) {
+        String drivingIdList = drivingIds.stream()
+                .map(id -> "'" + id + "'")
+                .reduce((a, b) -> a + "," + b)
+                .orElse("''");
+
+        return String.format("""
+            SELECT 
+              EXTRACT(DOW FROM CAST(timestamp AS timestamp)) as weekday,
+              CASE 
+                WHEN EXTRACT(HOUR FROM CAST(timestamp AS timestamp)) BETWEEN 0 AND 5 THEN 'DAWN'
+                WHEN EXTRACT(HOUR FROM CAST(timestamp AS timestamp)) BETWEEN 6 AND 9 THEN 'COMMUTE_TO_WORK'
+                WHEN EXTRACT(HOUR FROM CAST(timestamp AS timestamp)) BETWEEN 10 AND 16 THEN 'DAYTIME'
+                WHEN EXTRACT(HOUR FROM CAST(timestamp AS timestamp)) BETWEEN 17 AND 19 THEN 'COMMUTE_FROM_WORK'
+                ELSE 'EVENING'
+              END as time_slot,
+              eventType as event_type,
+              COUNT(*) as event_count
+            FROM event_data 
+            WHERE drivingId IN (%s)
+              AND eventType IN ('rapid_accel', 'hard_brake', 'lane_change')
+            GROUP BY 1, 2, 3
+            ORDER BY weekday, time_slot, event_type
+            """, drivingIdList);
+    }
+
+    private EventPatternProjection mapToProjection(Map<String, Object> row) {
+        return new EventPatternProjection() {
+            @Override
+            public Integer getWeekday() {
+                return ((Number) row.get("weekday")).intValue();
+            }
+
+            @Override
+            public String getTimeSlot() {
+                return (String) row.get("time_slot");
+            }
+
+            @Override
+            public String getEventType() {
+                return (String) row.get("event_type");
+            }
+
+            @Override
+            public Integer getEventCount() {
+                return ((Number) row.get("event_count")).intValue();
+            }
+        };
+    }
+    */
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorPatternAnalyzer.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorPatternAnalyzer.java
@@ -1,0 +1,212 @@
+package com.smooth.driving_analysis_service.reports.behavior.service;
+
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.DrivingPatternDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 위험행동 패턴 분석 로직을 담당하는 컴포넌트
+ */
+@Component
+@Slf4j
+public class BehaviorPatternAnalyzer {
+
+    private static final Map<Integer, String> WEEKDAY_MAP = Map.of(
+            1, "월", 2, "화", 3, "수", 4, "목", 5, "금", 6, "토", 7, "일"
+    );
+
+    private static final Map<String, String> TIMESLOT_MAP = Map.of(
+            "DAWN", "새벽",
+            "COMMUTE_TO_WORK", "출근", 
+            "DAYTIME", "낮",
+            "COMMUTE_FROM_WORK", "퇴근",
+            "EVENING", "저녁"
+    );
+
+    private static final List<String> TIMESLOT_PRIORITY = List.of(
+            "DAWN", "DAYTIME", "EVENING", "COMMUTE_TO_WORK", "COMMUTE_FROM_WORK"
+    );
+
+    /**
+     * 이벤트 패턴 데이터를 분석하여 DrivingPattern DTO로 변환
+     */
+    public DrivingPatternDto analyzeDrivingPattern(List<EventPatternProjection> eventPatterns) {
+        if (eventPatterns.isEmpty()) {
+            return createEmptyPattern();
+        }
+
+        // 1. 요일별 차트 데이터 생성
+        List<DrivingPatternDto.WeeklyChartDto> weeklyCharts = generateWeeklyCharts(eventPatterns);
+
+        // 2. 전체적으로 가장 빈번한 패턴 찾기
+        String dominantWeekday = findDominantWeekday(eventPatterns);
+        String dominantTimeSlot = findDominantTimeSlot(eventPatterns);
+
+        // 3. 코멘트 생성
+        String comment = generateComment(eventPatterns, dominantWeekday, dominantTimeSlot);
+
+        return DrivingPatternDto.builder()
+                .weekday(dominantWeekday)
+                .timeslot(dominantTimeSlot)
+                .chart(weeklyCharts)
+                .comment(comment)
+                .build();
+    }
+
+    private List<DrivingPatternDto.WeeklyChartDto> generateWeeklyCharts(List<EventPatternProjection> eventPatterns) {
+        List<DrivingPatternDto.WeeklyChartDto> charts = new ArrayList<>();
+
+        // 요일별로 그룹핑
+        Map<Integer, List<EventPatternProjection>> weekdayGroups = eventPatterns.stream()
+                .collect(Collectors.groupingBy(EventPatternProjection::getWeekday));
+
+        // 월~일 순서로 처리
+        for (int weekday = 1; weekday <= 7; weekday++) {
+            String weekdayName = WEEKDAY_MAP.get(weekday);
+            List<EventPatternProjection> weekdayEvents = weekdayGroups.getOrDefault(weekday, new ArrayList<>());
+
+            DrivingPatternDto.ActionsDto actions = generateActionsForWeekday(weekdayEvents);
+
+            charts.add(DrivingPatternDto.WeeklyChartDto.builder()
+                    .weekday(weekdayName)
+                    .actions(actions)
+                    .build());
+        }
+
+        return charts;
+    }
+
+    private DrivingPatternDto.ActionsDto generateActionsForWeekday(List<EventPatternProjection> weekdayEvents) {
+        // 행동별로 그룹핑하여 가장 많이 발생한 시간대 찾기
+        Map<String, List<EventPatternProjection>> actionGroups = weekdayEvents.stream()
+                .collect(Collectors.groupingBy(EventPatternProjection::getEventType));
+
+        return DrivingPatternDto.ActionsDto.builder()
+                .hardBrake(findDominantTimeSlotForAction(actionGroups.getOrDefault("hard_brake", new ArrayList<>())))
+                .rapidAccel(findDominantTimeSlotForAction(actionGroups.getOrDefault("rapid_accel", new ArrayList<>())))
+                .laneChange(findDominantTimeSlotForAction(actionGroups.getOrDefault("lane_change", new ArrayList<>())))
+                .build();
+    }
+
+    private DrivingPatternDto.ActionTimeSlotDto findDominantTimeSlotForAction(List<EventPatternProjection> actionEvents) {
+        if (actionEvents.isEmpty()) {
+            return null; // 데이터 없음
+        }
+
+        // 시간대별 합계 계산
+        Map<String, Integer> timeSlotCounts = actionEvents.stream()
+                .collect(Collectors.groupingBy(
+                        EventPatternProjection::getTimeSlot,
+                        Collectors.summingInt(EventPatternProjection::getEventCount)
+                ));
+
+        // 가장 많이 발생한 시간대 찾기 (동률시 우선순위 적용)
+        String dominantTimeSlot = timeSlotCounts.entrySet().stream()
+                .max((e1, e2) -> {
+                    int countCompare = e1.getValue().compareTo(e2.getValue());
+                    if (countCompare != 0) return countCompare;
+                    // 동률시 우선순위 적용
+                    return Integer.compare(
+                            TIMESLOT_PRIORITY.indexOf(e2.getKey()),
+                            TIMESLOT_PRIORITY.indexOf(e1.getKey())
+                    );
+                })
+                .map(Map.Entry::getKey)
+                .orElse("DAYTIME");
+
+        return DrivingPatternDto.ActionTimeSlotDto.builder()
+                .timeSlot(TIMESLOT_MAP.get(dominantTimeSlot))
+                .count(timeSlotCounts.get(dominantTimeSlot))
+                .build();
+    }
+
+    private String findDominantWeekday(List<EventPatternProjection> eventPatterns) {
+        Map<Integer, Integer> weekdayCounts = eventPatterns.stream()
+                .collect(Collectors.groupingBy(
+                        EventPatternProjection::getWeekday,
+                        Collectors.summingInt(EventPatternProjection::getEventCount)
+                ));
+
+        return weekdayCounts.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(entry -> WEEKDAY_MAP.get(entry.getKey()))
+                .orElse("금요일");
+    }
+
+    private String findDominantTimeSlot(List<EventPatternProjection> eventPatterns) {
+        Map<String, Integer> timeSlotCounts = eventPatterns.stream()
+                .collect(Collectors.groupingBy(
+                        EventPatternProjection::getTimeSlot,
+                        Collectors.summingInt(EventPatternProjection::getEventCount)
+                ));
+
+        String dominantTimeSlot = timeSlotCounts.entrySet().stream()
+                .max((e1, e2) -> {
+                    int countCompare = e1.getValue().compareTo(e2.getValue());
+                    if (countCompare != 0) return countCompare;
+                    // 동률시 우선순위 적용
+                    return Integer.compare(
+                            TIMESLOT_PRIORITY.indexOf(e2.getKey()),
+                            TIMESLOT_PRIORITY.indexOf(e1.getKey())
+                    );
+                })
+                .map(Map.Entry::getKey)
+                .orElse("EVENING");
+
+        return TIMESLOT_MAP.get(dominantTimeSlot);
+    }
+
+    private String generateComment(List<EventPatternProjection> eventPatterns, String dominantWeekday, String dominantTimeSlot) {
+        // 행동별 주요 시간대 분석
+        Map<String, String> actionTimeSlots = new HashMap<>();
+        
+        Map<String, List<EventPatternProjection>> actionGroups = eventPatterns.stream()
+                .collect(Collectors.groupingBy(EventPatternProjection::getEventType));
+
+        actionGroups.forEach((action, events) -> {
+            Map<String, Integer> timeSlotCounts = events.stream()
+                    .collect(Collectors.groupingBy(
+                            EventPatternProjection::getTimeSlot,
+                            Collectors.summingInt(EventPatternProjection::getEventCount)
+                    ));
+
+            String dominantSlot = timeSlotCounts.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(entry -> TIMESLOT_MAP.get(entry.getKey()))
+                    .orElse("낮");
+
+            actionTimeSlots.put(action, dominantSlot);
+        });
+
+        return String.format("%s %s에는 급제동과 급가속이 늘어나는 패턴이 보여요! %s 운전 시 조금 더 여유 있는 주행을 해보세요.",
+                dominantWeekday.contains("토") || dominantWeekday.contains("일") ? "주말" : "평일",
+                dominantTimeSlot,
+                dominantTimeSlot.equals("퇴근") ? "퇴근길" : dominantTimeSlot + " 시간대");
+    }
+
+    private DrivingPatternDto createEmptyPattern() {
+        List<DrivingPatternDto.WeeklyChartDto> emptyCharts = new ArrayList<>();
+        
+        for (int weekday = 1; weekday <= 7; weekday++) {
+            emptyCharts.add(DrivingPatternDto.WeeklyChartDto.builder()
+                    .weekday(WEEKDAY_MAP.get(weekday))
+                    .actions(DrivingPatternDto.ActionsDto.builder()
+                            .hardBrake(null)
+                            .rapidAccel(null)
+                            .laneChange(null)
+                            .build())
+                    .build());
+        }
+
+        return DrivingPatternDto.builder()
+                .weekday("금요일")
+                .timeslot("저녁")
+                .chart(emptyCharts)
+                .comment("아직 충분한 주행 데이터가 없어 패턴을 분석할 수 없습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorReportServiceImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorReportServiceImpl.java
@@ -1,12 +1,17 @@
 package com.smooth.driving_analysis_service.reports.behavior.service;
 
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
 import com.smooth.driving_analysis_service.reports.behavior.dto.response.BehaviorAnalysisResponseDto;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.DrivingPatternDto;
 import com.smooth.driving_analysis_service.reports.behavior.dto.response.TotalCountsDto;
+import com.smooth.driving_analysis_service.reports.behavior.repository.BehaviorPatternRepository;
 import com.smooth.driving_analysis_service.reports.behavior.repository.BehaviorTotalCountsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,10 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class BehaviorReportServiceImpl implements BehaviorReportService {
 
     private final BehaviorTotalCountsRepository totalCountsRepository;
+    private final BehaviorPatternRepository behaviorPatternRepository;
+    private final BehaviorPatternAnalyzer patternAnalyzer;
 
     @Override
     public BehaviorAnalysisResponseDto getBehaviorAnalysis(String reportId) {
-        log.info("Task 1: totalCounts 조회 - reportId: {}", reportId);
+        log.info("Task 1+2: totalCounts + drivingPattern 조회 - reportId: {}", reportId);
 
         try {
             // reportId에서 숫자 부분 추출 (예: "u1_r3_20250901" -> 3)
@@ -26,13 +33,16 @@ public class BehaviorReportServiceImpl implements BehaviorReportService {
 
             // Task 1: totalCounts 조회
             TotalCountsDto totalCounts = totalCountsRepository.findTotalCountsByReportId(reportIdLong);
-            
             if (totalCounts == null) {
                 log.warn("리포트 데이터 없음 - reportId: {}", reportId);
                 totalCounts = TotalCountsDto.of(0, 0, 0);
             }
 
-            // Task 1에서는 totalCounts만 구현
+            // Task 2: drivingPattern 조회 및 분석
+            List<EventPatternProjection> eventPatterns = behaviorPatternRepository.findEventPatternsByReportId(reportIdLong);
+            DrivingPatternDto drivingPattern = patternAnalyzer.analyzeDrivingPattern(eventPatterns);
+
+            // 응답 생성
             return BehaviorAnalysisResponseDto.builder()
                     .reportId(reportId)
                     .totalCounts(BehaviorAnalysisResponseDto.TotalCounts.builder()
@@ -41,18 +51,75 @@ public class BehaviorReportServiceImpl implements BehaviorReportService {
                             .laneChange(totalCounts.getLaneChange())
                             .total(totalCounts.getTotal())
                             .build())
+                    .drivingPattern(convertToDrivingPattern(drivingPattern))
                     .build();
 
         } catch (Exception e) {
             log.error("위험운전 행동 분석 조회 실패 - reportId: {}", reportId, e);
             // 오류 시 기본 데이터 반환
-            return BehaviorAnalysisResponseDto.builder()
-                    .reportId(reportId)
-                    .totalCounts(BehaviorAnalysisResponseDto.TotalCounts.builder()
-                            .hardBrake(0).rapidAccel(0).laneChange(0).total(0)
-                            .build())
-                    .build();
+            return createDefaultResponse(reportId);
         }
+    }
+
+    private BehaviorAnalysisResponseDto.DrivingPattern convertToDrivingPattern(DrivingPatternDto dto) {
+        List<BehaviorAnalysisResponseDto.WeeklyChart> charts = dto.getChart().stream()
+                .map(this::convertToWeeklyChart)
+                .toList();
+
+        return BehaviorAnalysisResponseDto.DrivingPattern.builder()
+                .weekday(dto.getWeekday())
+                .timeslot(dto.getTimeslot())
+                .chart(charts)
+                .comment(dto.getComment())
+                .build();
+    }
+
+    private BehaviorAnalysisResponseDto.WeeklyChart convertToWeeklyChart(DrivingPatternDto.WeeklyChartDto dto) {
+        return BehaviorAnalysisResponseDto.WeeklyChart.builder()
+                .weekday(dto.getWeekday())
+                .actions(BehaviorAnalysisResponseDto.Actions.builder()
+                        .hardBrake(convertToActionTimeSlot(dto.getActions().getHardBrake()))
+                        .rapidAccel(convertToActionTimeSlot(dto.getActions().getRapidAccel()))
+                        .laneChange(convertToActionTimeSlot(dto.getActions().getLaneChange()))
+                        .build())
+                .build();
+    }
+
+    private BehaviorAnalysisResponseDto.ActionTimeSlot convertToActionTimeSlot(DrivingPatternDto.ActionTimeSlotDto dto) {
+        if (dto == null) {
+            return null; // 데이터 없음
+        }
+        return BehaviorAnalysisResponseDto.ActionTimeSlot.builder()
+                .timeSlot(dto.getTimeSlot())
+                .count(dto.getCount())
+                .build();
+    }
+
+    private BehaviorAnalysisResponseDto createDefaultResponse(String reportId) {
+        return BehaviorAnalysisResponseDto.builder()
+                .reportId(reportId)
+                .totalCounts(BehaviorAnalysisResponseDto.TotalCounts.builder()
+                        .hardBrake(0).rapidAccel(0).laneChange(0).total(0)
+                        .build())
+                .drivingPattern(BehaviorAnalysisResponseDto.DrivingPattern.builder()
+                        .weekday("금요일")
+                        .timeslot("저녁")
+                        .chart(createEmptyWeeklyCharts())
+                        .comment("데이터 조회 중 오류가 발생했습니다.")
+                        .build())
+                .build();
+    }
+
+    private List<BehaviorAnalysisResponseDto.WeeklyChart> createEmptyWeeklyCharts() {
+        String[] weekdays = {"월", "화", "수", "목", "금", "토", "일"};
+        return List.of(weekdays).stream()
+                .map(weekday -> BehaviorAnalysisResponseDto.WeeklyChart.builder()
+                        .weekday(weekday)
+                        .actions(BehaviorAnalysisResponseDto.Actions.builder()
+                                .hardBrake(null).rapidAccel(null).laneChange(null)
+                                .build())
+                        .build())
+                .toList();
     }
 
     // === 유틸 메서드 ===

--- a/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneItemRepository.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/milestone/repository/MilestoneItemRepository.java
@@ -2,6 +2,8 @@ package com.smooth.driving_analysis_service.reports.milestone.repository;
 
 import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,5 +16,7 @@ public interface MilestoneItemRepository extends JpaRepository<MilestoneItem, Lo
     List<MilestoneItem> findByReportIdOrderByOrderNoAsc(Long reportId);
     List<MilestoneItem> findAllByReportIdOrderByOrderNoAsc(Long reportId);
 
+    @Query("SELECT mi.drivingId FROM MilestoneItem mi WHERE mi.reportId = :reportId ORDER BY mi.orderNo ASC")
+    List<String> findDrivingIdsByReportId(@Param("reportId") Long reportId);
 }
 

--- a/src/test/java/com/smooth/driving_analysis_service/reports/behavior/BehaviorTask1IntegrationTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/behavior/BehaviorTask1IntegrationTest.java
@@ -16,14 +16,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureWebMvc
 @ActiveProfiles("test")
 @Transactional
-@DisplayName("Behavior Task 1 통합 테스트")
+@DisplayName("Behavior Task 1+2 통합 테스트")
 class BehaviorTask1IntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("Task 1: API 엔드포인트 통합 테스트")
+    @DisplayName("Task 1+2: API 엔드포인트 통합 테스트 - totalCounts + drivingPattern")
     void getBehaviorAnalysis_Integration() throws Exception {
         // given
         String reportId = "u1_r1_20250901";
@@ -37,10 +37,19 @@ class BehaviorTask1IntegrationTest {
                 .andExpect(jsonPath("$.message").value("ok"))
                 .andExpect(jsonPath("$.data").exists())
                 .andExpect(jsonPath("$.data.reportId").value(reportId))
+                
+                // Task 1: totalCounts 검증
                 .andExpect(jsonPath("$.data.totalCounts").exists())
                 .andExpect(jsonPath("$.data.totalCounts.hardBrake").exists())
                 .andExpect(jsonPath("$.data.totalCounts.rapidAccel").exists())
                 .andExpect(jsonPath("$.data.totalCounts.laneChange").exists())
-                .andExpect(jsonPath("$.data.totalCounts.total").exists());
+                .andExpect(jsonPath("$.data.totalCounts.total").exists())
+                
+                // Task 2: drivingPattern 검증
+                .andExpect(jsonPath("$.data.drivingPattern").exists())
+                .andExpect(jsonPath("$.data.drivingPattern.weekday").exists())
+                .andExpect(jsonPath("$.data.drivingPattern.timeslot").exists())
+                .andExpect(jsonPath("$.data.drivingPattern.chart").exists())
+                .andExpect(jsonPath("$.data.drivingPattern.comment").exists());
     }
 }

--- a/src/test/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportControllerTask2Test.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportControllerTask2Test.java
@@ -1,0 +1,149 @@
+package com.smooth.driving_analysis_service.reports.behavior.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.BehaviorAnalysisResponseDto;
+import com.smooth.driving_analysis_service.reports.behavior.service.BehaviorReportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BehaviorReportController.class)
+@DisplayName("BehaviorReportController Task 2 테스트")
+class BehaviorReportControllerTask2Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BehaviorReportService behaviorReportService;
+
+    @Test
+    @DisplayName("Task 2: GET /api/driving-analysis/reports/{reportId}/behavior - drivingPattern 포함")
+    void getBehaviorAnalysis_WithDrivingPattern_Success() throws Exception {
+        // given
+        String reportId = "u1_r3_20250901";
+        BehaviorAnalysisResponseDto mockResponse = createMockResponseWithDrivingPattern(reportId);
+
+        when(behaviorReportService.getBehaviorAnalysis(anyString()))
+                .thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/driving-analysis/reports/{reportId}/behavior", reportId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("ok"))
+                .andExpect(jsonPath("$.data.reportId").value(reportId))
+                
+                // totalCounts 검증
+                .andExpect(jsonPath("$.data.totalCounts.hardBrake").value(38))
+                .andExpect(jsonPath("$.data.totalCounts.rapidAccel").value(42))
+                .andExpect(jsonPath("$.data.totalCounts.laneChange").value(17))
+                .andExpect(jsonPath("$.data.totalCounts.total").value(97))
+                
+                // drivingPattern 검증
+                .andExpect(jsonPath("$.data.drivingPattern").exists())
+                .andExpect(jsonPath("$.data.drivingPattern.weekday").value("금요일"))
+                .andExpect(jsonPath("$.data.drivingPattern.timeslot").value("저녁"))
+                .andExpect(jsonPath("$.data.drivingPattern.chart").isArray())
+                .andExpect(jsonPath("$.data.drivingPattern.comment").exists())
+                
+                // 월요일 차트 데이터 검증
+                .andExpect(jsonPath("$.data.drivingPattern.chart[0].weekday").value("월"))
+                .andExpect(jsonPath("$.data.drivingPattern.chart[0].actions.hardBrake.timeSlot").value("퇴근"))
+                .andExpect(jsonPath("$.data.drivingPattern.chart[0].actions.hardBrake.count").value(5));
+    }
+
+    @Test
+    @DisplayName("Task 2: 패턴 데이터 없는 경우 응답 검증")
+    void getBehaviorAnalysis_NoPatternData() throws Exception {
+        // given
+        String reportId = "u1_r999_20250901";
+        BehaviorAnalysisResponseDto mockResponse = createMockResponseWithEmptyPattern(reportId);
+
+        when(behaviorReportService.getBehaviorAnalysis(anyString()))
+                .thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/driving-analysis/reports/{reportId}/behavior", reportId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.drivingPattern.comment").value(org.hamcrest.Matchers.containsString("충분한 주행 데이터가 없어")));
+    }
+
+    private BehaviorAnalysisResponseDto createMockResponseWithDrivingPattern(String reportId) {
+        // 주간 차트 데이터 생성
+        List<BehaviorAnalysisResponseDto.WeeklyChart> weeklyCharts = new ArrayList<>();
+        String[] weekdays = {"월", "화", "수", "목", "금", "토", "일"};
+        
+        for (String weekday : weekdays) {
+            weeklyCharts.add(BehaviorAnalysisResponseDto.WeeklyChart.builder()
+                    .weekday(weekday)
+                    .actions(BehaviorAnalysisResponseDto.Actions.builder()
+                            .hardBrake(BehaviorAnalysisResponseDto.ActionTimeSlot.builder()
+                                    .timeSlot("퇴근").count(5).build())
+                            .rapidAccel(BehaviorAnalysisResponseDto.ActionTimeSlot.builder()
+                                    .timeSlot("출근").count(3).build())
+                            .laneChange(BehaviorAnalysisResponseDto.ActionTimeSlot.builder()
+                                    .timeSlot("낮").count(2).build())
+                            .build())
+                    .build());
+        }
+
+        return BehaviorAnalysisResponseDto.builder()
+                .reportId(reportId)
+                .totalCounts(BehaviorAnalysisResponseDto.TotalCounts.builder()
+                        .hardBrake(38).rapidAccel(42).laneChange(17).total(97)
+                        .build())
+                .drivingPattern(BehaviorAnalysisResponseDto.DrivingPattern.builder()
+                        .weekday("금요일")
+                        .timeslot("저녁")
+                        .chart(weeklyCharts)
+                        .comment("평일 저녁에는 급제동과 급가속이 늘어나는 패턴이 보여요!")
+                        .build())
+                .build();
+    }
+
+    private BehaviorAnalysisResponseDto createMockResponseWithEmptyPattern(String reportId) {
+        // 빈 주간 차트 데이터 생성
+        List<BehaviorAnalysisResponseDto.WeeklyChart> emptyCharts = new ArrayList<>();
+        String[] weekdays = {"월", "화", "수", "목", "금", "토", "일"};
+        
+        for (String weekday : weekdays) {
+            emptyCharts.add(BehaviorAnalysisResponseDto.WeeklyChart.builder()
+                    .weekday(weekday)
+                    .actions(BehaviorAnalysisResponseDto.Actions.builder()
+                            .hardBrake(null).rapidAccel(null).laneChange(null)
+                            .build())
+                    .build());
+        }
+
+        return BehaviorAnalysisResponseDto.builder()
+                .reportId(reportId)
+                .totalCounts(BehaviorAnalysisResponseDto.TotalCounts.builder()
+                        .hardBrake(0).rapidAccel(0).laneChange(0).total(0)
+                        .build())
+                .drivingPattern(BehaviorAnalysisResponseDto.DrivingPattern.builder()
+                        .weekday("금요일")
+                        .timeslot("저녁")
+                        .chart(emptyCharts)
+                        .comment("아직 충분한 주행 데이터가 없어 패턴을 분석할 수 없습니다.")
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorPatternAnalyzerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorPatternAnalyzerTest.java
@@ -1,0 +1,132 @@
+package com.smooth.driving_analysis_service.reports.behavior.service;
+
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.DrivingPatternDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BehaviorPatternAnalyzer 테스트")
+class BehaviorPatternAnalyzerTest {
+
+    @InjectMocks
+    private BehaviorPatternAnalyzer patternAnalyzer;
+
+    @Test
+    @DisplayName("정상적인 이벤트 패턴 분석")
+    void analyzeDrivingPattern_Success() {
+        // given
+        List<EventPatternProjection> eventPatterns = createMockEventPatterns();
+
+        // when
+        DrivingPatternDto result = patternAnalyzer.analyzeDrivingPattern(eventPatterns);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getWeekday()).isNotNull();
+        assertThat(result.getTimeslot()).isNotNull();
+        assertThat(result.getChart()).hasSize(7); // 월~일
+        assertThat(result.getComment()).isNotNull();
+
+        // 각 요일별 데이터 확인
+        result.getChart().forEach(weeklyChart -> {
+            assertThat(weeklyChart.getWeekday()).isNotNull();
+            assertThat(weeklyChart.getActions()).isNotNull();
+        });
+    }
+
+    @Test
+    @DisplayName("빈 데이터일 때 기본 패턴 반환")
+    void analyzeDrivingPattern_EmptyData() {
+        // given
+        List<EventPatternProjection> emptyPatterns = new ArrayList<>();
+
+        // when
+        DrivingPatternDto result = patternAnalyzer.analyzeDrivingPattern(emptyPatterns);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getWeekday()).isEqualTo("금요일");
+        assertThat(result.getTimeslot()).isEqualTo("저녁");
+        assertThat(result.getChart()).hasSize(7);
+        assertThat(result.getComment()).contains("충분한 주행 데이터가 없어");
+
+        // 모든 요일의 actions가 null인지 확인
+        result.getChart().forEach(weeklyChart -> {
+            assertThat(weeklyChart.getActions().getHardBrake()).isNull();
+            assertThat(weeklyChart.getActions().getRapidAccel()).isNull();
+            assertThat(weeklyChart.getActions().getLaneChange()).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("특정 요일에만 데이터가 있는 경우")
+    void analyzeDrivingPattern_PartialData() {
+        // given
+        List<EventPatternProjection> partialPatterns = List.of(
+                createEventPattern(5, "EVENING", "hard_brake", 10), // 금요일 저녁 급제동
+                createEventPattern(5, "COMMUTE_FROM_WORK", "rapid_accel", 5) // 금요일 퇴근 급가속
+        );
+
+        // when
+        DrivingPatternDto result = patternAnalyzer.analyzeDrivingPattern(partialPatterns);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getWeekday()).isEqualTo("금");
+        
+        // 금요일 데이터 확인
+        DrivingPatternDto.WeeklyChartDto fridayChart = result.getChart().get(4); // 금요일 (0-based index)
+        assertThat(fridayChart.getWeekday()).isEqualTo("금");
+        assertThat(fridayChart.getActions().getHardBrake()).isNotNull();
+        assertThat(fridayChart.getActions().getHardBrake().getTimeSlot()).isEqualTo("저녁");
+        assertThat(fridayChart.getActions().getHardBrake().getCount()).isEqualTo(10);
+        
+        // 다른 요일은 데이터 없음
+        DrivingPatternDto.WeeklyChartDto mondayChart = result.getChart().get(0); // 월요일
+        assertThat(mondayChart.getActions().getHardBrake()).isNull();
+    }
+
+    private List<EventPatternProjection> createMockEventPatterns() {
+        return List.of(
+                // 월요일
+                createEventPattern(1, "COMMUTE_TO_WORK", "hard_brake", 3),
+                createEventPattern(1, "DAYTIME", "rapid_accel", 2),
+                createEventPattern(1, "EVENING", "lane_change", 4),
+                
+                // 화요일
+                createEventPattern(2, "COMMUTE_FROM_WORK", "hard_brake", 5),
+                createEventPattern(2, "EVENING", "rapid_accel", 3),
+                createEventPattern(2, "DAYTIME", "lane_change", 2),
+                
+                // 금요일 (가장 많은 데이터)
+                createEventPattern(5, "EVENING", "hard_brake", 8),
+                createEventPattern(5, "COMMUTE_FROM_WORK", "rapid_accel", 6),
+                createEventPattern(5, "EVENING", "lane_change", 7)
+        );
+    }
+
+    private EventPatternProjection createEventPattern(int weekday, String timeSlot, String eventType, int count) {
+        return new EventPatternProjection() {
+            @Override
+            public Integer getWeekday() { return weekday; }
+            
+            @Override
+            public String getTimeSlot() { return timeSlot; }
+            
+            @Override
+            public String getEventType() { return eventType; }
+            
+            @Override
+            public Integer getEventCount() { return count; }
+        };
+    }
+}

--- a/src/test/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorReportServiceImplTask2Test.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/behavior/service/BehaviorReportServiceImplTask2Test.java
@@ -1,0 +1,188 @@
+package com.smooth.driving_analysis_service.reports.behavior.service;
+
+import com.smooth.driving_analysis_service.reports.behavior.dto.projection.EventPatternProjection;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.BehaviorAnalysisResponseDto;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.DrivingPatternDto;
+import com.smooth.driving_analysis_service.reports.behavior.dto.response.TotalCountsDto;
+import com.smooth.driving_analysis_service.reports.behavior.repository.BehaviorPatternRepository;
+import com.smooth.driving_analysis_service.reports.behavior.repository.BehaviorTotalCountsRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BehaviorReportService Task 2 테스트")
+class BehaviorReportServiceImplTask2Test {
+
+    @Mock
+    private BehaviorTotalCountsRepository totalCountsRepository;
+    
+    @Mock
+    private BehaviorPatternRepository behaviorPatternRepository;
+    
+    @Mock
+    private BehaviorPatternAnalyzer patternAnalyzer;
+
+    @InjectMocks
+    private BehaviorReportServiceImpl behaviorReportService;
+
+    @Test
+    @DisplayName("Task 2: totalCounts + drivingPattern 정상 조회")
+    void getBehaviorAnalysis_WithDrivingPattern_Success() {
+        // given
+        String reportId = "u1_r3_20250901";
+        TotalCountsDto mockTotalCounts = TotalCountsDto.of(38, 42, 17);
+        List<EventPatternProjection> mockEventPatterns = createMockEventPatterns();
+        DrivingPatternDto mockDrivingPattern = createMockDrivingPattern();
+        
+        when(totalCountsRepository.findTotalCountsByReportId(3L))
+                .thenReturn(mockTotalCounts);
+        when(behaviorPatternRepository.findEventPatternsByReportId(3L))
+                .thenReturn(mockEventPatterns);
+        when(patternAnalyzer.analyzeDrivingPattern(any()))
+                .thenReturn(mockDrivingPattern);
+
+        // when
+        BehaviorAnalysisResponseDto result = behaviorReportService.getBehaviorAnalysis(reportId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getReportId()).isEqualTo(reportId);
+        
+        // Task 1: totalCounts 검증
+        assertThat(result.getTotalCounts()).isNotNull();
+        assertThat(result.getTotalCounts().getHardBrake()).isEqualTo(38);
+        assertThat(result.getTotalCounts().getRapidAccel()).isEqualTo(42);
+        assertThat(result.getTotalCounts().getLaneChange()).isEqualTo(17);
+        assertThat(result.getTotalCounts().getTotal()).isEqualTo(97);
+        
+        // Task 2: drivingPattern 검증
+        assertThat(result.getDrivingPattern()).isNotNull();
+        assertThat(result.getDrivingPattern().getWeekday()).isEqualTo("금요일");
+        assertThat(result.getDrivingPattern().getTimeslot()).isEqualTo("저녁");
+        assertThat(result.getDrivingPattern().getChart()).hasSize(7);
+        assertThat(result.getDrivingPattern().getComment()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Task 2: 패턴 데이터 없을 때 기본값 반환")
+    void getBehaviorAnalysis_NoPatternData() {
+        // given
+        String reportId = "u1_r999_20250901";
+        TotalCountsDto mockTotalCounts = TotalCountsDto.of(5, 3, 2);
+        DrivingPatternDto emptyPattern = createEmptyDrivingPattern();
+        
+        when(totalCountsRepository.findTotalCountsByReportId(anyLong()))
+                .thenReturn(mockTotalCounts);
+        when(behaviorPatternRepository.findEventPatternsByReportId(anyLong()))
+                .thenReturn(new ArrayList<>());
+        when(patternAnalyzer.analyzeDrivingPattern(any()))
+                .thenReturn(emptyPattern);
+
+        // when
+        BehaviorAnalysisResponseDto result = behaviorReportService.getBehaviorAnalysis(reportId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getDrivingPattern()).isNotNull();
+        assertThat(result.getDrivingPattern().getComment()).contains("충분한 주행 데이터가 없어");
+    }
+
+    @Test
+    @DisplayName("Task 2: 예외 발생시 기본 응답 반환")
+    void getBehaviorAnalysis_ExceptionHandling() {
+        // given
+        String reportId = "invalid_format";
+        
+        when(totalCountsRepository.findTotalCountsByReportId(anyLong()))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // when
+        BehaviorAnalysisResponseDto result = behaviorReportService.getBehaviorAnalysis(reportId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getReportId()).isEqualTo(reportId);
+        assertThat(result.getTotalCounts().getTotal()).isEqualTo(0);
+        assertThat(result.getDrivingPattern()).isNotNull();
+        assertThat(result.getDrivingPattern().getComment()).contains("오류가 발생했습니다");
+    }
+
+    private List<EventPatternProjection> createMockEventPatterns() {
+        return List.of(
+                createEventPattern(5, "EVENING", "hard_brake", 8),
+                createEventPattern(5, "COMMUTE_FROM_WORK", "rapid_accel", 6)
+        );
+    }
+
+    private EventPatternProjection createEventPattern(int weekday, String timeSlot, String eventType, int count) {
+        return new EventPatternProjection() {
+            @Override
+            public Integer getWeekday() { return weekday; }
+            @Override
+            public String getTimeSlot() { return timeSlot; }
+            @Override
+            public String getEventType() { return eventType; }
+            @Override
+            public Integer getEventCount() { return count; }
+        };
+    }
+
+    private DrivingPatternDto createMockDrivingPattern() {
+        List<DrivingPatternDto.WeeklyChartDto> charts = new ArrayList<>();
+        String[] weekdays = {"월", "화", "수", "목", "금", "토", "일"};
+        
+        for (String weekday : weekdays) {
+            charts.add(DrivingPatternDto.WeeklyChartDto.builder()
+                    .weekday(weekday)
+                    .actions(DrivingPatternDto.ActionsDto.builder()
+                            .hardBrake(DrivingPatternDto.ActionTimeSlotDto.builder()
+                                    .timeSlot("퇴근").count(5).build())
+                            .rapidAccel(DrivingPatternDto.ActionTimeSlotDto.builder()
+                                    .timeSlot("출근").count(3).build())
+                            .laneChange(DrivingPatternDto.ActionTimeSlotDto.builder()
+                                    .timeSlot("낮").count(2).build())
+                            .build())
+                    .build());
+        }
+
+        return DrivingPatternDto.builder()
+                .weekday("금요일")
+                .timeslot("저녁")
+                .chart(charts)
+                .comment("평일 저녁에는 급제동과 급가속이 늘어나는 패턴이 보여요!")
+                .build();
+    }
+
+    private DrivingPatternDto createEmptyDrivingPattern() {
+        List<DrivingPatternDto.WeeklyChartDto> emptyCharts = new ArrayList<>();
+        String[] weekdays = {"월", "화", "수", "목", "금", "토", "일"};
+        
+        for (String weekday : weekdays) {
+            emptyCharts.add(DrivingPatternDto.WeeklyChartDto.builder()
+                    .weekday(weekday)
+                    .actions(DrivingPatternDto.ActionsDto.builder()
+                            .hardBrake(null).rapidAccel(null).laneChange(null)
+                            .build())
+                    .build());
+        }
+
+        return DrivingPatternDto.builder()
+                .weekday("금요일")
+                .timeslot("저녁")
+                .chart(emptyCharts)
+                .comment("아직 충분한 주행 데이터가 없어 패턴을 분석할 수 없습니다.")
+                .build();
+    }
+}


### PR DESCRIPTION
## 목적
운전 행동 분석 API의 두 번째 태스크(drivingPattern)를 구현했습니다.  
S3 event_data를 Athena로 쿼리하여 **요일별·시간대별 위험행동 패턴**을 분석하고,  
라인차트용 데이터와 자동 코멘트를 제공합니다.

---

## 구현/변경 사항
- [x] **Athena 쿼리**: S3 `event_data` 테이블에서 요일·시간대·행동별 집계
- [x] **패턴 분석**: 각 요일별 행동별 최다 발생 시간대 계산 (동률 시 우선순위 적용)
- [x] **라인차트 데이터**: 월~일 7개 요일별 위험행동 패턴 제공
- [x] **자동 코멘트**: 전체 패턴 기반 개인화된 운전 조언 생성
- [x] **시간대 분류**: 새벽(00-06), 출근(06-10), 낮(10-17), 퇴근(17-20), 저녁(20-24)
- [x] **우선순위 로직**: 동률 시 새벽 > 낮 > 저녁 > 출근 > 퇴근 순서 적용

---

## 테스트
- [x] **패턴 분석 테스트**: `BehaviorPatternAnalyzerTest` (정상/빈 데이터/부분 데이터)
- [x] **서비스 테스트**: `BehaviorReportServiceImplTask2Test` (Task 1+2 통합)
- [x] **컨트롤러 테스트**: `BehaviorReportControllerTask2Test` (API 응답 검증)
- [x] **통합 테스트**: `BehaviorTask1IntegrationTest` (전체 플로우 업데이트)

### 테스트 시나리오
- ✅ 정상 패턴 분석 (요일별, 시간대별 데이터)
- ✅ 빈 데이터 처리 (기본 패턴 반환)
- ✅ 부분 데이터 처리 (특정 요일만 데이터 있는 경우)
- ✅ 동률 시 우선순위 적용 검증
- ✅ Athena 쿼리 실패 시 예외 처리
