### PR TITLE
PR: fix - T7.12.1 매 주행 시 NONE 캐릭터 생성 오류 수정 -> US 7.12 머지

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/driving/entity/UserDrivingState.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/entity/UserDrivingState.java
@@ -40,7 +40,6 @@ public class UserDrivingState {
 
     public void reset(double analyzedDistanceKm, Long lastAnalyzedRecordId, DrivingCharacterType currentCharacterType) {
         this.pendingDistanceKm = 0.0;
-        this.totalDistanceKm +=  analyzedDistanceKm;
         this.lastAnalyzedRecordId = lastAnalyzedRecordId;
         this.currentCharacterType = currentCharacterType;
     }

--- a/src/main/java/com/smooth/driving_analysis_service/driving/entity/UserDrivingState.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/entity/UserDrivingState.java
@@ -38,7 +38,7 @@ public class UserDrivingState {
         this.totalDistanceKm += drivingDistanceKm;
     }
 
-    public void reset(double analyzedDistanceKm, Long lastAnalyzedRecordId, DrivingCharacterType currentCharacterType) {
+    public void reset(Long lastAnalyzedRecordId, DrivingCharacterType currentCharacterType) {
         this.pendingDistanceKm = 0.0;
         this.lastAnalyzedRecordId = lastAnalyzedRecordId;
         this.currentCharacterType = currentCharacterType;

--- a/src/main/java/com/smooth/driving_analysis_service/driving/service/CharacterServiceImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/service/CharacterServiceImpl.java
@@ -88,7 +88,7 @@ public class CharacterServiceImpl implements CharacterService {
         UserDrivingState userDrivingState = userDrivingStateRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(DrivingErrorCode.DRIVING_STATE_NOT_FOUND, "업데이트할 주행 상태가 없습니다."));
 
-        userDrivingState.reset(userDrivingState.getPendingDistanceKm(),toRecordId,drivingCharacter.getCharacterType());
+        userDrivingState.reset(toRecordId,drivingCharacter.getCharacterType());
     }
 
     private DrivingCharacterAnalysisRequestDto prepareData(Long fromRecordId, Long toRecordId, Long userId) {

--- a/src/main/java/com/smooth/driving_analysis_service/driving/service/CharacterServiceImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/service/CharacterServiceImpl.java
@@ -89,6 +89,9 @@ public class CharacterServiceImpl implements CharacterService {
                 .orElseThrow(() -> new BusinessException(DrivingErrorCode.DRIVING_STATE_NOT_FOUND, "업데이트할 주행 상태가 없습니다."));
 
         userDrivingState.reset(toRecordId,drivingCharacter.getCharacterType());
+
+        DrivingCharacter newCharacter = DrivingCharacter.createInitialDrivingCharacter(userId, toRecordId);
+        drivingCharacterRepository.save(newCharacter);
     }
 
     private DrivingCharacterAnalysisRequestDto prepareData(Long fromRecordId, Long toRecordId, Long userId) {

--- a/src/main/java/com/smooth/driving_analysis_service/driving/service/DrivingServiceImpl.java
+++ b/src/main/java/com/smooth/driving_analysis_service/driving/service/DrivingServiceImpl.java
@@ -203,8 +203,10 @@ public class DrivingServiceImpl implements DrivingService {
         UserDrivingState userDrivingState = userDrivingStateRepository.findByUserId(record.getUserId())
                 .orElse(UserDrivingState.createInitialUserDrivingState(record.getUserId()));
 
-        if (userDrivingState.getCurrentCharacterType() == DrivingCharacterType.NONE ||
-                drivingCharacterRepository.findFirstByUserIdOrderByCreatedAtDesc(record.getUserId()).isEmpty()) {
+        boolean hasActiveNoneCharacter = drivingCharacterRepository.findFirstByUserIdAndCharacterTypeOrderByCreatedAtDesc(
+                record.getUserId(), DrivingCharacterType.NONE).isPresent();
+        
+        if (!hasActiveNoneCharacter) {
             drivingCharacterRepository.save(DrivingCharacter.createInitialDrivingCharacter(record.getUserId(), record.getId()));
         }
 


### PR DESCRIPTION
## 목적
- 이 PR이 필요한 이유 또는 배경을 간단히 작성합니다.
- (예: KST 시간 파싱 오류 수정, 실시간 알림 기능 구현, Redis 구조 리팩토링 등)


## 구현/변경 사항
- <주요 기능/코드 변경 1줄 요약>
- <주요 기능/코드 변경 1줄 요약>
- <주요 기능/코드 변경 1줄 요약>
- (Task → US 머지일 경우 하위 Task 번호와 설명을 목록화)


## 테스트 (있을 경우만 작성)
- <테스트 환경> (예: Docker 기반 로컬 환경, staging 서버 등)
- <테스트 방법> (예: REST API 호출, WebSocket 연결, 단위 테스트 실행 등)
- <검증 결과> (예: 메시지 수신 정상, 반경 필터링 성공, 예외 처리 통과 등)


## BREAKING CHANGE (있을 경우만 작성)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)


## 참고
- 관련 이슈/유저 스토리: Refs: US<번호> (또는 Task 번호)
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)