### PR TITLE
# PR: test - 컨트롤러 인증 도입에 따른 테스트 모킹 추가

### DIFF
--- a/src/main/java/com/smooth/driving_analysis_service/batch/controller/BatchAdminController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/batch/controller/BatchAdminController.java
@@ -13,6 +13,7 @@ import java.util.Map;
 @Profile("!test")
 @RequiredArgsConstructor
 @RequestMapping("/api/driving-analysis/internal/batch")
+
 @ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = false)
 public class BatchAdminController {
 

--- a/src/main/java/com/smooth/driving_analysis_service/batch/controller/ReportDebugController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/batch/controller/ReportDebugController.java
@@ -1,5 +1,6 @@
 package com.smooth.driving_analysis_service.batch.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.milestone.entity.MilestoneReport;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -21,6 +22,7 @@ public class ReportDebugController {
 
     @GetMapping("/{reportId}/summary")
     public Map<String, Object> summary(@PathVariable Long reportId) {
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
         var report = em.find(MilestoneReport.class, reportId);
         Long items = em.createQuery(
                         "select count(i) from MilestoneItem i where i.report.id=:rid", Long.class)
@@ -52,6 +54,7 @@ public class ReportDebugController {
     }
 
     private long count(String table, Long reportId, String type) {
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
         String sql = "select count(*) from " + table +
                 " where report_id = :rid and snapshot_type = :type";
         Number n = (Number) em.createNativeQuery(sql)

--- a/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionController.java
@@ -1,5 +1,6 @@
 package com.smooth.driving_analysis_service.reports.accident_reaction.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.accident_reaction.dto.request.AccidentReactionRenderedRequestDto;
 import com.smooth.driving_analysis_service.reports.accident_reaction.dto.response.AccidentReactionReportResponseDto;
 import com.smooth.driving_analysis_service.reports.accident_reaction.service.AccidentReactionService;
@@ -23,6 +24,7 @@ public class AccidentReactionController {
      */
     @GetMapping("/{reportId}/accident-response")
     public ResponseEntity<?> getAccidentReactionReport(@PathVariable String reportId) {
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
         AccidentReactionReportResponseDto data = accidentReactionReportService.getFullReport(reportId);
         return ResponseEntity.ok(Map.of("success", true, "code", "SUCCESS", "message", "ok", "data", data));
     }
@@ -35,6 +37,7 @@ public class AccidentReactionController {
             @PathVariable String alertId,
             @RequestParam Long userId,
             @RequestBody AccidentReactionRenderedRequestDto request) {
+        Long authenticatedUserId = AuthenticationUtils.getCurrentUserIdOrThrow();
         
         String drivingId = accidentReactionService.recordAndAnalyzeAsync(
             alertId, userId, request.getRenderedAtMs(), request.getType());

--- a/src/main/java/com/smooth/driving_analysis_service/reports/basic_summary/controller/BasicSummaryController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/basic_summary/controller/BasicSummaryController.java
@@ -1,5 +1,6 @@
 package com.smooth.driving_analysis_service.reports.basic_summary.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.global.common.ApiResponse;
 import com.smooth.driving_analysis_service.global.exception.CommonErrorCode;
 import com.smooth.driving_analysis_service.reports.basic_summary.dto.BasicSummaryResponse;
@@ -21,7 +22,8 @@ public class BasicSummaryController {
      */
     @GetMapping("/{reportId}/basic-summary")
     public ApiResponse<BasicSummaryResponse> getBasicSummary(@PathVariable Long reportId) {
-        log.info("Getting basic summary for reportId={}", reportId);
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        log.info("Getting basic summary for reportId={}, userId={}", reportId, userId);
         
         BasicSummaryResponse summary = basicSummaryService.getBasicSummary(reportId);
         

--- a/src/main/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportController.java
@@ -1,5 +1,6 @@
 package com.smooth.driving_analysis_service.reports.behavior.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.behavior.dto.response.BehaviorAnalysisResponseDto;
 import com.smooth.driving_analysis_service.reports.behavior.service.BehaviorReportService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ public class BehaviorReportController {
     /** Task 1: totalCounts 구현 - 위험운전 행동 분석 API */
     @GetMapping("/{reportId}/behavior")
     public ResponseEntity<?> getBehaviorAnalysis(@PathVariable String reportId) {
-        log.info("위험운전 행동 분석 API 호출 - reportId: {}", reportId);
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        log.info("위험운전 행동 분석 API 호출 - reportId: {}, userId: {}", reportId, userId);
         
         BehaviorAnalysisResponseDto analysis = service.getBehaviorAnalysis(reportId);
         

--- a/src/main/java/com/smooth/driving_analysis_service/reports/dna/controller/DnaController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/reports/dna/controller/DnaController.java
@@ -1,5 +1,6 @@
 package com.smooth.driving_analysis_service.reports.dna.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.dna.dto.response.DnaAnalysisResponseDto;
 import com.smooth.driving_analysis_service.reports.dna.service.DnaService;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,8 @@ public class DnaController {
      */
     @GetMapping("/{reportId}/dna")
     public ResponseEntity<?> getDnaAnalysis(@PathVariable String reportId) {
-        log.info("운전 성향 DNA 분석 API 호출 - reportId: {}", reportId);
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        log.info("운전 성향 DNA 분석 API 호출 - reportId: {}, userId: {}", reportId, userId);
         
         DnaAnalysisResponseDto analysis = dnaService.getDnaAnalysis(reportId);
         

--- a/src/main/java/com/smooth/driving_analysis_service/timeline/controller/TimeLineController.java
+++ b/src/main/java/com/smooth/driving_analysis_service/timeline/controller/TimeLineController.java
@@ -1,6 +1,7 @@
 package com.smooth.driving_analysis_service.timeline.controller;
 
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.global.common.ApiResponse;
 import com.smooth.driving_analysis_service.timeline.dto.TimeLineResponseDto;
 import com.smooth.driving_analysis_service.timeline.service.TimeLineService;
@@ -23,7 +24,8 @@ public class TimeLineController {
     public ResponseEntity<ApiResponse<TimeLineResponseDto>> getDrivingTimeLine(
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "10") int limit) {
-        TimeLineResponseDto dto = timeLineService.getDrivingTimeLine(1L, cursor, limit); // TODO: X-User-Id 헤더로 교체
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        TimeLineResponseDto dto = timeLineService.getDrivingTimeLine(userId, cursor, limit);
         return ResponseEntity.ok(ApiResponse.success("주행 타임라인 조회가 완료되었습니다.", dto));
     }
 
@@ -33,7 +35,8 @@ public class TimeLineController {
     public ResponseEntity<ApiResponse<TimeLineResponseDto>> getReportTimeLine(
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "10") int limit) {
-        TimeLineResponseDto dto = timeLineService.getReportTimeLine(1L, cursor, limit);
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        TimeLineResponseDto dto = timeLineService.getReportTimeLine(userId, cursor, limit);
         return ResponseEntity.ok(ApiResponse.success("리포트 타임라인 조회가 완료되었습니다.", dto));
     }
 
@@ -43,7 +46,8 @@ public class TimeLineController {
     public ResponseEntity<ApiResponse<TimeLineResponseDto>> getAllTimeLine(
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "10") int limit) {
-        TimeLineResponseDto dto = timeLineService.getAllTimeLine(1L, cursor, limit);
+        Long userId = AuthenticationUtils.getCurrentUserIdOrThrow();
+        TimeLineResponseDto dto = timeLineService.getAllTimeLine(userId, cursor, limit);
         return ResponseEntity.ok(ApiResponse.success("전체 타임라인 조회가 완료되었습니다.", dto));
     }
 }

--- a/src/test/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionControllerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/accident_reaction/controller/AccidentReactionControllerTest.java
@@ -1,20 +1,24 @@
 package com.smooth.driving_analysis_service.reports.accident_reaction.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.accident_reaction.dto.request.AccidentReactionRenderedRequestDto;
 import com.smooth.driving_analysis_service.reports.accident_reaction.dto.response.AccidentReactionBenchmarkDto;
 import com.smooth.driving_analysis_service.reports.accident_reaction.dto.response.AccidentReactionReportResponseDto;
 import com.smooth.driving_analysis_service.reports.accident_reaction.service.AccidentReactionService;
 import com.smooth.driving_analysis_service.reports.accident_reaction.service.AccidentReactionReportService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -27,11 +31,25 @@ class AccidentReactionControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private AccidentReactionService accidentReactionService;
 
-    @MockBean
+    @MockitoBean
     private AccidentReactionReportService accidentReactionReportService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
 
     @Test
     void testGetAccidentReactionReport_Success() throws Exception {

--- a/src/test/java/com/smooth/driving_analysis_service/reports/basic_summary/BasicSummaryControllerUnitTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/basic_summary/BasicSummaryControllerUnitTest.java
@@ -1,10 +1,14 @@
 package com.smooth.driving_analysis_service.reports.basic_summary;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.basic_summary.controller.BasicSummaryController;
 import com.smooth.driving_analysis_service.reports.basic_summary.dto.BasicSummaryResponse;
 import com.smooth.driving_analysis_service.reports.basic_summary.service.BasicSummaryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -12,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -25,6 +29,20 @@ class BasicSummaryControllerUnitTest {
 
     @MockitoBean
     private BasicSummaryService basicSummaryService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
 
     @Test
     @DisplayName("API 호출 성공 - 200 응답")

--- a/src/test/java/com/smooth/driving_analysis_service/reports/basic_summary/controller/BasicSummaryControllerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/basic_summary/controller/BasicSummaryControllerTest.java
@@ -1,10 +1,14 @@
 package com.smooth.driving_analysis_service.reports.basic_summary.controller;
 
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.basic_summary.dto.BasicSummaryResponse;
 import com.smooth.driving_analysis_service.reports.basic_summary.service.BasicSummaryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -13,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDate;
 
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -25,6 +29,20 @@ class BasicSummaryControllerTest {
     
     @MockitoBean
     private BasicSummaryService basicSummaryService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
     
     @Test
     @DisplayName("기본 요약 조회 API 성공")

--- a/src/test/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportControllerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/behavior/controller/BehaviorReportControllerTest.java
@@ -1,16 +1,20 @@
 package com.smooth.driving_analysis_service.reports.behavior.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.behavior.dto.response.BehaviorAnalysisResponseDto;
 import com.smooth.driving_analysis_service.reports.behavior.service.BehaviorReportService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,8 +26,22 @@ class BehaviorReportControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private BehaviorReportService behaviorReportService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
 
     @Test
     @DisplayName("GET /api/reports/behavior/{reportId} - 정상 응답")

--- a/src/test/java/com/smooth/driving_analysis_service/reports/dna/controller/DnaControllerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/reports/dna/controller/DnaControllerTest.java
@@ -1,18 +1,21 @@
 package com.smooth.driving_analysis_service.reports.dna.controller;
 
-
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.reports.dna.dto.response.DnaAnalysisResponseDto;
 import com.smooth.driving_analysis_service.reports.dna.service.DnaService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -23,8 +26,22 @@ class DnaControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private DnaService dnaService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
 
     @Test
     @DisplayName("DNA 분석 API 정상 호출")

--- a/src/test/java/com/smooth/driving_analysis_service/timeline/controller/TimeLineControllerTest.java
+++ b/src/test/java/com/smooth/driving_analysis_service/timeline/controller/TimeLineControllerTest.java
@@ -1,12 +1,16 @@
 package com.smooth.driving_analysis_service.timeline.controller;
 
+import com.smooth.driving_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.driving_analysis_service.timeline.dto.TimeLineResponseDto;
 import com.smooth.driving_analysis_service.timeline.service.TimeLineService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,6 +22,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -32,8 +37,22 @@ class TimeLineControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TimeLineService timeLineService;
+    
+    private MockedStatic<AuthenticationUtils> authUtilsMock;
+    
+    @BeforeEach
+    void setUp() {
+        authUtilsMock = mockStatic(AuthenticationUtils.class);
+        authUtilsMock.when(AuthenticationUtils::getCurrentUserIdOrThrow)
+                     .thenReturn(1L);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        authUtilsMock.close();
+    }
 
     @Test
     @DisplayName("전체 타임라인 조회 - 성공")


### PR DESCRIPTION
## 개요
컨트롤러에 인증 로직을 도입한 이후 실패하던 테스트들을 **정적 모킹과 테스트 설정 정리**로 복구했습니다.  
본 PR은 **프로덕션 코드 변경 없이 테스트 코드/설정만** 수정합니다.

## 변경 내용
- **AuthenticationUtils 정적 모킹 도입**
  - `MockedStatic<AuthenticationUtils>`로 현재 사용자 ID/역할 스텁
  - 공통 `setUp/tearDown`에서 모킹 생성/해제하여 누수 방지
- **Deprecated 어노테이션 교체**
  - `@MockBean` → **`@MockitoBean`**
- **테스트 인프라 정비**
  - 각 컨트롤러 테스트 클래스에 공통 초기화/해제 메서드 추가
  - 기본 스텁: `userId = 1L`, `role = USER` (ADMIN 케이스는 테스트별로 덮어쓰기)

